### PR TITLE
Cast peak into a float for cases where it isn't 

### DIFF
--- a/morituri/rip/cd.py
+++ b/morituri/rip/cd.py
@@ -431,7 +431,7 @@ Install pycdio and run 'rip offset find' to detect your drive's offset.
                     raise
 
                 self.stdout.write('Peak level: %.2f %%\n' % (
-                    math.sqrt(trackResult.peak) * 100.0, ))
+                    float(math.sqrt(trackResult.peak) * 100.0, )))
                 self.stdout.write('Rip quality: %.2f %%\n' % (
                     trackResult.quality * 100.0, ))
 


### PR DESCRIPTION
(e.g. when HTOA generates a peak of 0)

Whipper was crashing after processing some HTOA tracks that it found. It found a track 36 frames long, and the peak quality was 0, so the math function generated a 0 but the print string was looking for the float. So I gave it one. Shouldn't cause any harm.