### PR TITLE
Resolve case where _peakdB is None

### DIFF
--- a/morituri/common/encode.py
+++ b/morituri/common/encode.py
@@ -337,7 +337,6 @@ class EncodeTask(ctask.GstPipelineTask):
             if self._length == common.SAMPLES_PER_FRAME:
                 self.warning('only one frame of audio, setting peak to 0.0')
                 self.peak = 0.0
-        return
 
 class TagReadTask(ctask.GstPipelineTask):
     """

--- a/morituri/common/encode.py
+++ b/morituri/common/encode.py
@@ -329,13 +329,15 @@ class EncodeTask(ctask.GstPipelineTask):
 
         self.warning('No peak found.')
 
+        self.peak = 0.0
+
         if self._duration:
             self.warning('GStreamer level element did not send messages.')
             # workaround for when the file is too short to have volume ?
             if self._length == common.SAMPLES_PER_FRAME:
                 self.warning('only one frame of audio, setting peak to 0.0')
                 self.peak = 0.0
-
+        return
 
 class TagReadTask(ctask.GstPipelineTask):
     """

--- a/morituri/rip/cd.py
+++ b/morituri/rip/cd.py
@@ -431,7 +431,7 @@ Install pycdio and run 'rip offset find' to detect your drive's offset.
                     raise
 
                 self.stdout.write('Peak level: %.2f %%\n' % (
-                    math.sqrt(trackResult.peak) * 100.0, ))
+                    float(math.sqrt(trackResult.peak) * 100.0, )))
                 self.stdout.write('Rip quality: %.2f %%\n' % (
                     trackResult.quality * 100.0, ))
 

--- a/morituri/rip/cd.py
+++ b/morituri/rip/cd.py
@@ -430,10 +430,9 @@ Install pycdio and run 'rip offset find' to detect your drive's offset.
                         number)
                     raise
 
-                self.stdout.write('Peak level: %.2f %%\n' % (
-                    float(math.sqrt(trackResult.peak) * 100.0, )))
-                self.stdout.write('Rip quality: %.2f %%\n' % (
-                    trackResult.quality * 100.0, ))
+                self.stdout.write('Peak level: {:.2%} \n'.format(math.sqrt(trackResult.peak)))
+
+                self.stdout.write('Rip quality: {:.2%}\n'.format(trackResult.quality))
 
             # overlay this rip onto the Table
             if number == 0:


### PR DESCRIPTION
When _peakdB is none (sometimes happens with HTOA), peak is not set to a float number, causing the output to crash with a TypeError: a float is required on line 434 of cd.py.  This pull request will fix this (and changes the strings in this section of cd.py to use the newer str.format convention).