### PR TITLE
undelete overzealously removed plugin initialisation

### DIFF
--- a/morituri/rip/main.py
+++ b/morituri/rip/main.py
@@ -17,6 +17,11 @@ def main():
     # set user agent
     musicbrainzngs.set_useragent("morituri", configure.version,
         'https://thomas.apestaart.org/morituri/trac')
+    # register plugins with pkg_resources
+    plugins = directory.Directory().getData('plugins')
+    distributions, errors = pkg_resources.working_set.find_plugins(
+                            pkg_resources.Environment([plugins]))
+    map(pkg_resources.working_set.add, distributions)
     c = Rip()
     try:
         ret = c.parse(sys.argv[1:])

--- a/morituri/rip/main.py
+++ b/morituri/rip/main.py
@@ -18,9 +18,9 @@ def main():
     musicbrainzngs.set_useragent("morituri", configure.version,
         'https://thomas.apestaart.org/morituri/trac')
     # register plugins with pkg_resources
-    plugins = directory.Directory().getData('plugins')
-    distributions, errors = pkg_resources.working_set.find_plugins(
-                            pkg_resources.Environment([plugins]))
+    distributions, _ = pkg_resources.working_set.find_plugins(
+        pkg_resources.Environment([directory.Directory().getData('plugins')])
+    )
     map(pkg_resources.working_set.add, distributions)
     c = Rip()
     try:


### PR DESCRIPTION
I made a mistake when converting to setuptools and accidentally deleted some glue code for plugin initialisation. This restores that, albeit in a slightly simpler form.