### PR TITLE
Error reporting enhancements

### DIFF
--- a/morituri/image/image.py
+++ b/morituri/image/image.py
@@ -250,6 +250,8 @@ class ImageVerifyTask(log.Loggable, task.MultiSeparateTask):
                 self.setException(taskk.exception)
                 break
 
+            assert taskk.length is not None, ("Track length was not found; "
+                    "look for earlier errors in debug log (set RIP_DEBUG=4)")
             # print '%d has length %d' % (trackIndex, taskk.length)
             index = track.indexes[1]
             assert taskk.length % common.SAMPLES_PER_FRAME == 0

--- a/morituri/rip/main.py
+++ b/morituri/rip/main.py
@@ -45,7 +45,10 @@ def main():
                 'rip: error: Could not create encoded file.\n')
             return 255
 
-        raise
+        # in python3 we can instead do `raise e.exception` as that would show
+        # the exception's original context
+        sys.stderr.write(e.exceptionMessage)
+        return 255
     except command.CommandError, e:
         sys.stderr.write('rip: error: %s\n' % e.output)
         return e.status


### PR DESCRIPTION
two enhancements in error reporting i'd like to suggest; the first is probably uncontroversial, the second should improve messages for all error cases as far as i understand the use of TaskException (but that understanding might be wrong).

note that to best see what these do, try running `rip image verify` without gst installed. (without those changes, it's tricky to find what's wrong).