### PR TITLE
cdrdao no-disc ejection & --eject

### DIFF
--- a/morituri/command/cd.py
+++ b/morituri/command/cd.py
@@ -587,8 +587,6 @@ Log files will log the path to tracks relative to this directory.
         # write log file
         self.program.writeLog(discName, self.logger)
 
-        utils.eject_device(self.device)
-
 
 class CD(BaseCommand):
     summary = "handle CDs"

--- a/morituri/command/cd.py
+++ b/morituri/command/cd.py
@@ -34,7 +34,7 @@ from morituri.command.basecommand import BaseCommand
 from morituri.common import (
     accurip, common, config, drive, gstreamer, program, task
 )
-from morituri.program import cdrdao, cdparanoia
+from morituri.program import cdrdao, cdparanoia, utils
 from morituri.result import result
 
 import logging
@@ -108,8 +108,8 @@ class _CD(BaseCommand):
         self.device = self.options.device
         sys.stdout.write('Checking device %s\n' % self.device)
 
-        self.program.loadDevice(self.device)
-        self.program.unmountDevice(self.device)
+        utils.load_device(self.device)
+        utils.unmount_device(self.device)
 
         # first, read the normal TOC, which is fast
         self.ittoc = self.program.getFastToc(self.runner,
@@ -141,7 +141,7 @@ class _CD(BaseCommand):
             # also used by rip cd info
             if not getattr(self.options, 'unknown', False):
                 if self.eject:
-                    self.program.ejectDevice(self.device)
+                    utils.eject_device(self.device)
                 return -1
 
         # FIXME ?????
@@ -206,7 +206,7 @@ class _CD(BaseCommand):
         self.doCommand()
 
         if self.eject:
-            self.program.ejectDevice(self.device)
+            utils.eject_device(self.device)
 
     def doCommand(self):
         pass
@@ -587,7 +587,7 @@ Log files will log the path to tracks relative to this directory.
         # write log file
         self.program.writeLog(discName, self.logger)
 
-        self.program.ejectDevice(self.device)
+        utils.eject_device(self.device)
 
 
 class CD(BaseCommand):

--- a/morituri/command/cd.py
+++ b/morituri/command/cd.py
@@ -205,7 +205,7 @@ class _CD(BaseCommand):
 
         self.doCommand()
 
-        if self.eject:
+        if self.options.eject in ('success', 'always'):
             utils.eject_device(self.device)
 
     def doCommand(self):

--- a/morituri/command/cd.py
+++ b/morituri/command/cd.py
@@ -140,8 +140,8 @@ class _CD(BaseCommand):
 
             # also used by rip cd info
             if not getattr(self.options, 'unknown', False):
-                if self.eject:
-                    utils.eject_device(self.device)
+                logger.critical("unable to retrieve disc metadata, "
+                                "--unknown not passed")
                 return -1
 
         # FIXME ?????

--- a/morituri/command/main.py
+++ b/morituri/command/main.py
@@ -26,10 +26,12 @@ def main():
     )
     map(pkg_resources.working_set.add, distributions)
     try:
-        ret = Whipper(sys.argv[1:], os.path.basename(sys.argv[0]), None).do()
+        cmd = Whipper(sys.argv[1:], os.path.basename(sys.argv[0]), None)
+        ret = cmd.do()
     except SystemError, e:
         sys.stderr.write('whipper: error: %s\n' % e)
-        if type(e) is common.EjectError:
+        if (type(e) is common.EjectError and
+                cmd.options.eject in ('failure', 'always')):
             eject_device(e.device)
         return 255
     except ImportError, e:
@@ -79,6 +81,10 @@ You can get help on subcommands by using the -h option to the subcommand.
         self.parser.add_argument('-h', '--help',
                             action="store_true", dest="help",
                             help="show this help message and exit")
+        self.parser.add_argument('-e', '--eject',
+                            action="store", dest="eject", default="always",
+                            choices=('never', 'failure', 'success', 'always'),
+                            help="when to eject disc (default: always)")
 
     def handle_arguments(self):
         if self.options.help:

--- a/morituri/command/main.py
+++ b/morituri/command/main.py
@@ -11,6 +11,7 @@ from morituri.command.basecommand import BaseCommand
 from morituri.common import common, directory
 from morituri.configure import configure
 from morituri.extern.task import task
+from morituri.program.utils import eject_device
 
 import logging
 logger = logging.getLogger(__name__)
@@ -27,7 +28,9 @@ def main():
     try:
         ret = Whipper(sys.argv[1:], os.path.basename(sys.argv[0]), None).do()
     except SystemError, e:
-        sys.stderr.write('whipper: error: %s\n' % e.args)
+        sys.stderr.write('whipper: error: %s\n' % e)
+        if type(e) is common.EjectError:
+            eject_device(e.device)
         return 255
     except ImportError, e:
         raise ImportError(e)

--- a/morituri/command/offset.py
+++ b/morituri/command/offset.py
@@ -31,7 +31,7 @@ gobject.threads_init()
 from morituri.command.basecommand import BaseCommand
 from morituri.common import accurip, common, config, drive, program
 from morituri.common import task as ctask
-from morituri.program import cdrdao, cdparanoia
+from morituri.program import cdrdao, cdparanoia, utils
 
 from morituri.extern.task import task
 
@@ -88,8 +88,8 @@ CD in the AccurateRip database."""
         # if necessary, load and unmount
         sys.stdout.write('Checking device %s\n' % device)
 
-        prog.loadDevice(device)
-        prog.unmountDevice(device)
+        utils.load_device(device)
+        utils.unmount_device(device)
 
         # first get the Table Of Contents of the CD
         t = cdrdao.ReadTOCTask(device)

--- a/morituri/common/common.py
+++ b/morituri/common/common.py
@@ -39,6 +39,19 @@ WORDS_PER_FRAME = SAMPLES_PER_FRAME * 2
 BYTES_PER_FRAME = SAMPLES_PER_FRAME * 4
 
 
+class EjectError(SystemError):
+    """
+    Possibly ejects the drive in command.main.
+    """
+    def __init__(self, device, *args):
+        """
+        args is a tuple used by BaseException.__str__
+        device is the device path to eject
+        """
+        self.args = args
+        self.device = device
+
+
 def msfToFrames(msf):
     """
     Converts a string value in MM:SS:FF to frames.

--- a/morituri/common/program.py
+++ b/morituri/common/program.py
@@ -90,32 +90,6 @@ class Program:
             logger.info('Changing to working directory %s' % workingDirectory)
             os.chdir(workingDirectory)
 
-    def loadDevice(self, device):
-        """
-        Load the given device.
-        """
-        os.system('eject -t %s' % device)
-
-    def ejectDevice(self, device):
-        """
-        Eject the given device.
-        """
-        os.system('eject %s' % device)
-
-    def unmountDevice(self, device):
-        """
-        Unmount the given device if it is mounted, as happens with automounted
-        data tracks.
-
-        If the given device is a symlink, the target will be checked.
-        """
-        device = os.path.realpath(device)
-        logger.debug('possibly unmount real path %r' % device)
-        proc = open('/proc/mounts').read()
-        if device in proc:
-            print 'Device %s is mounted, unmounting' % device
-            os.system('umount %s' % device)
-
     def getFastToc(self, runner, toc_pickle, device):
         """
         Retrieve the normal TOC table from a toc pickle or the drive.

--- a/morituri/program/utils.py
+++ b/morituri/program/utils.py
@@ -1,0 +1,35 @@
+import os
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+def eject_device(device):
+    """
+    Eject the given device.
+    """
+    logger.debug("ejecting device %s", device)
+    os.system('eject %s' % device)
+
+
+def load_device(device):
+    """
+    Load the given device.
+    """
+    logger.debug("loading (eject -t) device %s", device)
+    os.system('eject -t %s' % device)
+    
+    
+def unmount_device(device):
+    """
+    Unmount the given device if it is mounted, as happens with automounted
+    data tracks.
+
+    If the given device is a symlink, the target will be checked.
+    """
+    device = os.path.realpath(device)
+    logger.debug('possibly unmount real path %r' % device)
+    proc = open('/proc/mounts').read()
+    if device in proc:
+        print 'Device %s is mounted, unmounting' % device
+        os.system('umount %s' % device)


### PR DESCRIPTION
If the first disc-read task (`cdrdao read-toc --fast-toc ...`) fails due to being unable to read the disc at all, raise a (newly introduced) `EjectError` (subclass of `SystemError`).

Introduces the `whipper` level option `-e, --eject {never,failure,success,always}`, with a default of `always`. If `--eject` is `failure` or 'always`, an EjectError will eject the disc. If `--eject` is `success` or `always`, eject after a successful rip.