### PR TITLE
lazy image properties

### DIFF
--- a/morituri/command/cd.py
+++ b/morituri/command/cd.py
@@ -119,7 +119,7 @@ class _CD(BaseCommand):
         # already show us some info based on this
         self.program.getRipResult(self.ittoc.getCDDBDiscId())
         sys.stdout.write("CDDB disc id: %s\n" % self.ittoc.getCDDBDiscId())
-        self.mbdiscid = self.ittoc.getMusicBrainzDiscId()
+        self.mbdiscid = self.ittoc.musicbrainz_discid
         sys.stdout.write("MusicBrainz disc id %s\n" % self.mbdiscid)
 
         sys.stdout.write("MusicBrainz lookup URL %s\n" %
@@ -157,23 +157,23 @@ class _CD(BaseCommand):
         # now, read the complete index table, which is slower
         self.itable = self.program.getTable(self.runner,
             self.ittoc.getCDDBDiscId(),
-            self.ittoc.getMusicBrainzDiscId(), self.device, offset)
+            self.ittoc.musicbrainz_discid, self.device, offset)
 
         assert self.itable.getCDDBDiscId() == self.ittoc.getCDDBDiscId(), \
             "full table's id %s differs from toc id %s" % (
                 self.itable.getCDDBDiscId(), self.ittoc.getCDDBDiscId())
-        assert self.itable.getMusicBrainzDiscId() == \
-            self.ittoc.getMusicBrainzDiscId(), \
+        assert self.itable.musicbrainz_discid == \
+            self.ittoc.musicbrainz_discid, \
             "full table's mb id %s differs from toc id mb %s" % (
-            self.itable.getMusicBrainzDiscId(),
-            self.ittoc.getMusicBrainzDiscId())
+            self.itable.musicbrainz_discid,
+            self.ittoc.musicbrainz_discid)
         assert self.itable.getAccurateRipURL() == \
             self.ittoc.getAccurateRipURL(), \
             "full table's AR URL %s differs from toc AR URL %s" % (
             self.itable.getAccurateRipURL(), self.ittoc.getAccurateRipURL())
 
         if self.program.metadata:
-            self.program.metadata.discid = self.ittoc.getMusicBrainzDiscId()
+            self.program.metadata.discid = self.ittoc.musicbrainz_discid
 
         # result
 
@@ -222,6 +222,7 @@ class Info(_CD):
 
     def add_arguments(self):
         _CD.add_arguments(self.parser)
+
 
 class Rip(_CD):
     summary = "rip CD"

--- a/morituri/command/cd.py
+++ b/morituri/command/cd.py
@@ -133,8 +133,7 @@ class _CD(BaseCommand):
 
         if not self.program.metadata:
             # fall back to FreeDB for lookup
-            cddbid = self.ittoc.getCDDBValues()
-            cddbmd = self.program.getCDDB(cddbid)
+            cddbmd = self.program.getCDDB(self.ittoc.cddb_values)
             if cddbmd:
                 sys.stdout.write('FreeDB identifies disc as %s\n' % cddbmd)
 

--- a/morituri/command/cd.py
+++ b/morituri/command/cd.py
@@ -117,8 +117,8 @@ class _CD(BaseCommand):
             self.device)
 
         # already show us some info based on this
-        self.program.getRipResult(self.ittoc.getCDDBDiscId())
-        sys.stdout.write("CDDB disc id: %s\n" % self.ittoc.getCDDBDiscId())
+        self.program.getRipResult(self.ittoc.cddb_discid)
+        sys.stdout.write("CDDB disc id: %s\n" % self.ittoc.cddb_discid)
         self.mbdiscid = self.ittoc.musicbrainz_discid
         sys.stdout.write("MusicBrainz disc id %s\n" % self.mbdiscid)
 
@@ -155,12 +155,12 @@ class _CD(BaseCommand):
 
         # now, read the complete index table, which is slower
         self.itable = self.program.getTable(self.runner,
-            self.ittoc.getCDDBDiscId(),
+            self.ittoc.cddb_discid,
             self.ittoc.musicbrainz_discid, self.device, offset)
 
-        assert self.itable.getCDDBDiscId() == self.ittoc.getCDDBDiscId(), \
+        assert self.itable.cddb_discid == self.ittoc.cddb_discid, \
             "full table's id %s differs from toc id %s" % (
-                self.itable.getCDDBDiscId(), self.ittoc.getCDDBDiscId())
+                self.itable.cddb_discid, self.ittoc.cddb_discid)
         assert self.itable.musicbrainz_discid == \
             self.ittoc.musicbrainz_discid, \
             "full table's mb id %s differs from toc id mb %s" % (
@@ -571,7 +571,7 @@ Log files will log the path to tracks relative to this directory.
             sys.stdout.write('%d AccurateRip reponses found\n' %
                 len(responses))
 
-            if responses[0].cddbDiscId != self.itable.getCDDBDiscId():
+            if responses[0].cddbDiscId != self.itable.cddb_discid:
                 sys.stdout.write(
                     "AccurateRip response discid different: %s\n" %
                     responses[0].cddbDiscId)

--- a/morituri/command/cd.py
+++ b/morituri/command/cd.py
@@ -166,10 +166,10 @@ class _CD(BaseCommand):
             "full table's mb id %s differs from toc id mb %s" % (
             self.itable.musicbrainz_discid,
             self.ittoc.musicbrainz_discid)
-        assert self.itable.getAccurateRipURL() == \
-            self.ittoc.getAccurateRipURL(), \
+        assert self.itable.accuraterip_url == \
+            self.ittoc.accuraterip_url, \
             "full table's AR URL %s differs from toc AR URL %s" % (
-            self.itable.getAccurateRipURL(), self.ittoc.getAccurateRipURL())
+            self.itable.accuraterip_url, self.ittoc.accuraterip_url)
 
         if self.program.metadata:
             self.program.metadata.discid = self.ittoc.musicbrainz_discid
@@ -547,7 +547,7 @@ Log files will log the path to tracks relative to this directory.
         handle.close()
 
         # verify using accuraterip
-        url = self.ittoc.getAccurateRipURL()
+        url = self.ittoc.accuraterip_url
         sys.stdout.write("AccurateRip URL %s\n" % url)
 
         accucache = accurip.AccuCache()

--- a/morituri/command/cd.py
+++ b/morituri/command/cd.py
@@ -123,7 +123,7 @@ class _CD(BaseCommand):
         sys.stdout.write("MusicBrainz disc id %s\n" % self.mbdiscid)
 
         sys.stdout.write("MusicBrainz lookup URL %s\n" %
-            self.ittoc.getMusicBrainzSubmitURL())
+            self.ittoc.musicbrainz_submit_url)
 
         self.program.metadata = self.program.getMusicBrainz(self.ittoc,
             self.mbdiscid,

--- a/morituri/command/cd.py
+++ b/morituri/command/cd.py
@@ -390,7 +390,7 @@ Log files will log the path to tracks relative to this directory.
             assert type(path) is unicode, "%r is not unicode" % path
             trackResult.filename = path
             if number > 0:
-                trackResult.pregap = self.itable.tracks[number - 1].getPregap()
+                trackResult.pregap = self.itable.tracks[number - 1].pregap
 
             # FIXME: optionally allow overriding reripping
             if os.path.exists(path):

--- a/morituri/command/image.py
+++ b/morituri/command/image.py
@@ -127,8 +127,7 @@ Verifies the image from the given .cue files against the AccurateRip database.
             cueImage = image.Image(arg)
             cueImage.setup(runner)
 
-            url = cueImage.table.getAccurateRipURL()
-            responses = cache.retrieve(url)
+            responses = cache.retrieve(cueImage.table.accuraterip_url)
 
             # FIXME: this feels like we're poking at internals.
             prog.cuePath = arg

--- a/morituri/command/image.py
+++ b/morituri/command/image.py
@@ -75,7 +75,7 @@ Retags the image from the given .cue files with tags obtained from MusicBrainz.
             sys.stdout.write('MusicBrainz disc id is %s\n' % mbdiscid)
 
             sys.stdout.write("MusicBrainz lookup URL %s\n" %
-                cueImage.table.getMusicBrainzSubmitURL())
+                cueImage.table.musicbrainz_submit_url)
             prog.metadata = prog.getMusicBrainz(cueImage.table, mbdiscid,
                 release=self.options.release_id,
                 country=self.options.country,

--- a/morituri/command/image.py
+++ b/morituri/command/image.py
@@ -71,7 +71,7 @@ Retags the image from the given .cue files with tags obtained from MusicBrainz.
             cueImage = image.Image(arg)
             cueImage.setup(runner)
 
-            mbdiscid = cueImage.table.getMusicBrainzDiscId()
+            mbdiscid = cueImage.table.musicbrainz_discid
             sys.stdout.write('MusicBrainz disc id is %s\n' % mbdiscid)
 
             sys.stdout.write("MusicBrainz lookup URL %s\n" %

--- a/morituri/command/offset.py
+++ b/morituri/command/offset.py
@@ -95,7 +95,7 @@ CD in the AccurateRip database."""
         t = cdrdao.ReadTOCTask(device)
         table = t.table
 
-        logger.debug("CDDB disc id: %r", table.getCDDBDiscId())
+        logger.debug("CDDB disc id: %r", table.cddb_discid)
         url = table.getAccurateRipURL()
         logger.debug("AccurateRip URL: %s", url)
 
@@ -117,7 +117,7 @@ CD in the AccurateRip database."""
         if responses:
             logger.debug('%d AccurateRip responses found.' % len(responses))
 
-            if responses[0].cddbDiscId != table.getCDDBDiscId():
+            if responses[0].cddbDiscId != table.cddb_discid:
                 logger.warning("AccurateRip response discid different: %s",
                     responses[0].cddbDiscId)
 

--- a/morituri/command/offset.py
+++ b/morituri/command/offset.py
@@ -96,20 +96,18 @@ CD in the AccurateRip database."""
         table = t.table
 
         logger.debug("CDDB disc id: %r", table.cddb_discid)
-        url = table.getAccurateRipURL()
-        logger.debug("AccurateRip URL: %s", url)
+        logger.debug("AccurateRip URL: %s", table.accuraterip_url)
 
         # FIXME: download url as a task too
         responses = []
         import urllib2
         try:
-            handle = urllib2.urlopen(url)
+            handle = urllib2.urlopen(table.accuraterip_url)
             data = handle.read()
             responses = accurip.getAccurateRipResponses(data)
         except urllib2.HTTPError, e:
             if e.code == 404:
-                sys.stdout.write(
-                    'Album not found in AccurateRip database.\n')
+                sys.stdout.write('Album not found in AccurateRip database.\n')
                 return 1
             else:
                 raise

--- a/morituri/common/cache.py
+++ b/morituri/common/cache.py
@@ -214,9 +214,9 @@ class TableCache:
         if not ptable.object:
             ptable = self._pcache.get(cddbdiscid)
             if ptable.object:
-                if ptable.object.getMusicBrainzDiscId() != mbdiscid:
+                if ptable.object.musicbrainz_discid != mbdiscid:
                     logger.debug('cached table is for different mb id %r' % (
-                        ptable.object.getMusicBrainzDiscId()))
+                        ptable.object.musicbrainz_discid))
                 ptable.object = None
             else:
                 logger.debug('no valid cached table found for %r' %

--- a/morituri/common/common.py
+++ b/morituri/common/common.py
@@ -367,3 +367,19 @@ def getRevision():
         return revision
 
     return '(unknown)'
+
+
+class lazy_property(object):
+    """
+    Decorator for properties that you want to compute, lazily, just once.
+
+    From http://stackoverflow.com/a/6849299
+    See also http://docs.python.org/3/howto/descriptor.html for reference.
+    """
+    def __init__(self, f):
+        self.f = f
+
+    def __get__(self, instance, cls):
+        result = self.f(instance)
+        setattr(instance, self.f.__name__, result)
+        return result

--- a/morituri/common/program.py
+++ b/morituri/common/program.py
@@ -319,8 +319,7 @@ class Program:
         self._stdout.write('Disc duration: %s, %d audio tracks\n' % (
             common.formatTime(ittoc.duration() / 1000.0),
             ittoc.getAudioTracks()))
-        logger.debug('MusicBrainz submit url: %r',
-            ittoc.getMusicBrainzSubmitURL())
+        logger.debug('MusicBrainz submit url: %r', ittoc.musicbrainz_submit_url)
         ret = None
 
         metadatas = None

--- a/morituri/common/program.py
+++ b/morituri/common/program.py
@@ -178,7 +178,7 @@ class Program:
         self.result.table = itable
 
         logger.debug('getTable: returning table with mb id %s' %
-            itable.getMusicBrainzDiscId())
+            itable.musicbrainz_discid)
         return itable
 
     def getRipResult(self, cddbdiscid):

--- a/morituri/common/program.py
+++ b/morituri/common/program.py
@@ -536,12 +536,12 @@ class Program:
         """
         track = self.result.table.tracks[0]
         try:
-            index = track.getIndex(0)
+            index = track.indexes[0]
         except KeyError:
             return None
 
         start = index.absolute
-        stop = track.getIndex(1).absolute - 1
+        stop = track.indexes[1].absolute - 1
         return (start, stop)
 
     def verifyTrack(self, runner, trackResult):

--- a/morituri/image/image.py
+++ b/morituri/image/image.py
@@ -85,7 +85,7 @@ class Image(object):
         if verify.lengths.has_key(0):
             offset = verify.lengths[0]
         else:
-            offset = self.cue.table.tracks[0].getIndex(1).relative
+            offset = self.cue.table.tracks[0].indexes[1].relative
 
         tracks = []
 
@@ -98,7 +98,7 @@ class Image(object):
             # FIXME: this probably only works for non-compliant .CUE files
             # where pregap is put at end of previous file
             t.index(1, absolute=offset,
-                path=self.cue.table.tracks[i].getIndex(1).path,
+                path=self.cue.table.tracks[i].indexes[1].path,
                 relative=0)
 
             offset += length

--- a/morituri/image/table.py
+++ b/morituri/image/table.py
@@ -480,7 +480,8 @@ class Table(object):
         logger.debug('Musicbrainz values: %r', result)
         return result
 
-    def getAccurateRipIds(self):
+    @common.lazy_property
+    def accuraterip_ids(self):
         """
         Calculate the two AccurateRip ID's.
 
@@ -519,7 +520,7 @@ class Table(object):
         @returns: the AccurateRip URL
         @rtype:   str
         """
-        discId1, discId2 = self.getAccurateRipIds()
+        discId1, discId2 = self.accuraterip_ids
 
         return "http://www.accuraterip.com/accuraterip/" \
             "%s/%s/%s/dBAR-%.3d-%s-%s-%s.bin" % (

--- a/morituri/image/table.py
+++ b/morituri/image/table.py
@@ -101,7 +101,8 @@ class Track:
     def getIndex(self, number):
         return self.indexes[number]
 
-    def getFirstIndex(self):
+    @common.lazy_property
+    def first_index(self):
         """
         Get the first chronological index for this track.
 
@@ -112,12 +113,14 @@ class Track:
         indexes.sort()
         return self.indexes[indexes[0]]
 
-    def getLastIndex(self):
+    @common.lazy_property
+    def last_index(self):
         indexes = self.indexes.keys()
         indexes.sort()
         return self.indexes[indexes[-1]]
 
-    def getPregap(self):
+    @common.lazy_property
+    def pregap(self):
         """
         Returns the length of the pregap for this track.
 
@@ -574,7 +577,7 @@ class Table(object):
         # add the first FILE line; EAC always puts the first FILE
         # statement before TRACK 01 and any possible PRE-GAP
         firstTrack = self.tracks[0]
-        index = firstTrack.getFirstIndex()
+        index = firstTrack.first_index
         indexOne = firstTrack.getIndex(1)
         counter = index.counter
         track = firstTrack
@@ -668,7 +671,7 @@ class Table(object):
         # FIXME: do a loop over track indexes better, with a pythonic
         # construct that allows you to do for t, i in ...
         t = self.tracks[0].number
-        index = self.tracks[0].getFirstIndex()
+        index = self.tracks[0].first_index
         i = index.number
 
         logger.debug('clearing path')
@@ -724,7 +727,7 @@ class Table(object):
         Only possible for as long as tracks draw from the same file.
         """
         t = self.tracks[0].number
-        index = self.tracks[0].getFirstIndex()
+        index = self.tracks[0].first_index
         i = index.number
         # the first cut is the deepest
         counter = index.counter
@@ -767,7 +770,7 @@ class Table(object):
         gap = self._getSessionGap(session)
 
         trackCount = len(self.tracks)
-        sourceCounter = self.tracks[-1].getLastIndex().counter
+        sourceCounter = self.tracks[-1].last_index.counter
 
         for track in other.tracks:
             t = copy.deepcopy(track)

--- a/morituri/image/table.py
+++ b/morituri/image/table.py
@@ -390,7 +390,8 @@ class Table(object):
         logger.debug('mbdiscid: returning %r' % result)
         return result
 
-    def getMusicBrainzSubmitURL(self):
+    @common.lazy_property
+    def musicbrainz_submit_url(self):
         host = 'musicbrainz.org'
 
         discid = self.musicbrainz_discid

--- a/morituri/image/table.py
+++ b/morituri/image/table.py
@@ -324,7 +324,8 @@ class Table(object):
 
         return result
 
-    def getCDDBDiscId(self):
+    @common.lazy_property
+    def cddb_discid(self):
         """
         Calculate the CDDB disc ID.
 
@@ -341,7 +342,7 @@ class Table(object):
         @rtype:   str
         @returns: the 28-character base64-encoded disc ID
         """
-        values = self._getMusicBrainzValues()
+        values = self._musicbrainz_values
 
         # MusicBrainz disc id does not take into account data tracks
         # P2.3
@@ -395,7 +396,7 @@ class Table(object):
         host = 'musicbrainz.org'
 
         discid = self.musicbrainz_discid
-        values = self._getMusicBrainzValues()
+        values = self._musicbrainz_values
 
         query = urllib.urlencode({
             'id': discid,
@@ -430,7 +431,8 @@ class Table(object):
         """
         return int(self.getFrameLength() * 1000.0 / common.FRAMES_PER_SECOND)
 
-    def _getMusicBrainzValues(self):
+    @common.lazy_property
+    def _musicbrainz_values(self):
         """
         Get all MusicBrainz values needed to calculate disc id and submit URL.
 
@@ -521,7 +523,7 @@ class Table(object):
         return "http://www.accuraterip.com/accuraterip/" \
             "%s/%s/%s/dBAR-%.3d-%s-%s-%s.bin" % (
                 discId1[-1], discId1[-2], discId1[-3],
-                self.getAudioTracks(), discId1, discId2, self.getCDDBDiscId())
+                self.getAudioTracks(), discId1, discId2, self.cddb_discid)
 
     def cue(self, cuePath='', program='morituri'):
         """
@@ -551,7 +553,7 @@ class Table(object):
                     lines.append("    %s %s" % (key, self.cdtext[key]))
 
         assert self.hasTOC(), "Table does not represent a full CD TOC"
-        lines.append('REM DISCID %s' % self.getCDDBDiscId().upper())
+        lines.append('REM DISCID %s' % self.cddb_discid.upper())
         lines.append('REM COMMENT "%s %s"' % (program, configure.version))
 
         if self.catalog:

--- a/morituri/image/table.py
+++ b/morituri/image/table.py
@@ -259,7 +259,8 @@ class Table(object):
 
         return ret
 
-    def getCDDBValues(self):
+    @common.lazy_property
+    def cddb_values(self):
         """
         Get all CDDB values needed to calculate disc id and lookup URL.
 
@@ -330,8 +331,7 @@ class Table(object):
         @rtype:   str
         @returns: the 8-character hexadecimal disc ID
         """
-        values = self.getCDDBValues()
-        return "%08x" % values[0]
+        return "%08x" % self.cddb_values[0]
 
     @common.lazy_property
     def musicbrainz_discid(self):

--- a/morituri/image/table.py
+++ b/morituri/image/table.py
@@ -205,7 +205,7 @@ class Table(object):
         @rtype:   int
         """
         track = self.tracks[number - 1]
-        return track.getIndex(1).absolute
+        return track.indexes[1].absolute
 
     def getTrackEnd(self, number):
         """
@@ -220,7 +220,7 @@ class Table(object):
 
         # if not last track, calculate it from the next track
         if number < len(self.tracks):
-            end = self.tracks[number].getIndex(1).absolute - 1
+            end = self.tracks[number].indexes[1].absolute - 1
 
             # if on a session border, subtract the session leadin
             thisTrack = self.tracks[number - 1]
@@ -463,7 +463,7 @@ class Table(object):
         # for the leadout
         if self.hasDataTracks():
             assert not self.tracks[-1].audio
-            leadout = self.tracks[-1].getIndex(1).absolute - 11250 - 150
+            leadout = self.tracks[-1].indexes[1].absolute - 11250 - 150
 
         # treat leadout offset as track 0 offset
         result.append(150 + leadout)
@@ -474,7 +474,7 @@ class Table(object):
                 track = self.tracks[i - 1]
                 if not track.audio:
                     continue
-                offset = track.getIndex(1).absolute + 150
+                offset = track.indexes[1].absolute + 150
                 result.append(offset)
             except IndexError:
                 pass
@@ -578,14 +578,14 @@ class Table(object):
         # statement before TRACK 01 and any possible PRE-GAP
         firstTrack = self.tracks[0]
         index = firstTrack.first_index
-        indexOne = firstTrack.getIndex(1)
+        indexOne = firstTrack.indexes[1]
         counter = index.counter
         track = firstTrack
 
         while not index.path:
             t, i = self.getNextTrackIndex(track.number, index.number)
             track = self.tracks[t - 1]
-            index = track.getIndex(i)
+            index = track.indexes[i]
             counter = index.counter
 
         if index.path:
@@ -677,7 +677,7 @@ class Table(object):
         logger.debug('clearing path')
         while True:
             track = self.tracks[t - 1]
-            index = track.getIndex(i)
+            index = track.indexes[i]
             logger.debug('Clearing path on track %d, index %d', t, i)
             index.path = None
             index.relative = None
@@ -736,7 +736,7 @@ class Table(object):
         logger.debug('absolutizing')
         while True:
             track = self.tracks[t - 1]
-            index = track.getIndex(i)
+            index = track.indexes[i]
             assert track.number == t
             assert index.number == i
             if index.counter is None:

--- a/morituri/image/table.py
+++ b/morituri/image/table.py
@@ -98,9 +98,6 @@ class Track:
         i = Index(number, absolute, path, relative, counter)
         self.indexes[number] = i
 
-    def getIndex(self, number):
-        return self.indexes[number]
-
     @common.lazy_property
     def first_index(self):
         """

--- a/morituri/image/table.py
+++ b/morituri/image/table.py
@@ -333,17 +333,14 @@ class Table(object):
         values = self.getCDDBValues()
         return "%08x" % values[0]
 
-    def getMusicBrainzDiscId(self):
+    @common.lazy_property
+    def musicbrainz_discid(self):
         """
         Calculate the MusicBrainz disc ID.
 
         @rtype:   str
         @returns: the 28-character base64-encoded disc ID
         """
-        if self.mbdiscid:
-            logger.debug('getMusicBrainzDiscId: returning cached %r'
-                         % self.mbdiscid)
-            return self.mbdiscid
         values = self._getMusicBrainzValues()
 
         # MusicBrainz disc id does not take into account data tracks
@@ -390,14 +387,13 @@ class Table(object):
         assert len(result) == 28, \
             "Result should be 28 characters, not %d" % len(result)
 
-        logger.debug('getMusicBrainzDiscId: returning %r' % result)
-        self.mbdiscid = result
+        logger.debug('mbdiscid: returning %r' % result)
         return result
 
     def getMusicBrainzSubmitURL(self):
         host = 'musicbrainz.org'
 
-        discid = self.getMusicBrainzDiscId()
+        discid = self.musicbrainz_discid
         values = self._getMusicBrainzValues()
 
         query = urllib.urlencode({

--- a/morituri/image/table.py
+++ b/morituri/image/table.py
@@ -511,7 +511,8 @@ class Table(object):
 
         return ("%08x" % discId1, "%08x" % discId2)
 
-    def getAccurateRipURL(self):
+    @common.lazy_property
+    def accuraterip_url(self):
         """
         Return the full AccurateRip URL.
 

--- a/morituri/image/toc.py
+++ b/morituri/image/toc.py
@@ -166,7 +166,7 @@ class TocFile(object):
         logger.debug(
             '[track %02d index %02d] trackOffset %r, added %r',
                 currentTrack.number, i, trackOffset,
-                currentTrack.getIndex(i))
+                currentTrack.indexes[i])
 
 
     def parse(self):
@@ -357,7 +357,7 @@ class TocFile(object):
                     absolute=absoluteOffset,
                     relative=relativeOffset, counter=c)
                 logger.debug('[track %02d index 00] added %r',
-                    currentTrack.number, currentTrack.getIndex(0))
+                    currentTrack.number, currentTrack.indexes[0])
                 # store the pregapLength to add it when we index 1 for this
                 # track on the next iteration
                 pregapLength = length

--- a/morituri/result/logger.py
+++ b/morituri/result/logger.py
@@ -70,7 +70,7 @@ class MorituriLogger(result.Logger):
         # CD metadata
         lines.append("CD metadata:")
         lines.append("  Album: %s - %s" % (ripResult.artist, ripResult.title))
-        lines.append("  CDDB Disc ID: %s" % ripResult. table.getCDDBDiscId())
+        lines.append("  CDDB Disc ID: %s" % ripResult.table.cddb_discid)
         lines.append("  MusicBrainz Disc ID: %s" %
                      ripResult. table.musicbrainz_discid)
         lines.append("  MusicBrainz lookup url: %s" %

--- a/morituri/result/logger.py
+++ b/morituri/result/logger.py
@@ -84,7 +84,7 @@ class MorituriLogger(result.Logger):
         # Test for HTOA presence
         htoa = None
         try:
-            htoa = table.tracks[0].getIndex(0)
+            htoa = table.tracks[0].indexes[0]
         except KeyError:
             pass
 
@@ -92,7 +92,7 @@ class MorituriLogger(result.Logger):
         if htoa and htoa.path:
             htoastart = htoa.absolute
             htoaend = table.getTrackEnd(0)
-            htoalength = table.tracks[0].getIndex(1).absolute - htoastart
+            htoalength = table.tracks[0].indexes[1].absolute - htoastart
             lines.append("  00:")
             lines.append("    Start: %s" % common.framesToMSF(htoastart))
             lines.append("    Length: %s" % common.framesToMSF(htoalength))
@@ -104,7 +104,7 @@ class MorituriLogger(result.Logger):
         for t in table.tracks:
             # FIXME: what happens to a track start over 60 minutes ?
             # Answer: tested empirically, everything seems OK
-            start = t.getIndex(1).absolute
+            start = t.indexes[1].absolute
             length = table.getTrackLength(t.number)
             end = table.getTrackEnd(t.number)
             lines.append("  %02d:" % t.number)

--- a/morituri/result/logger.py
+++ b/morituri/result/logger.py
@@ -72,7 +72,7 @@ class MorituriLogger(result.Logger):
         lines.append("  Album: %s - %s" % (ripResult.artist, ripResult.title))
         lines.append("  CDDB Disc ID: %s" % ripResult. table.getCDDBDiscId())
         lines.append("  MusicBrainz Disc ID: %s" %
-                     ripResult. table.getMusicBrainzDiscId())
+                     ripResult. table.musicbrainz_discid)
         lines.append("  MusicBrainz lookup url: %s" %
                      ripResult. table.getMusicBrainzSubmitURL())
         lines.append("")

--- a/morituri/result/logger.py
+++ b/morituri/result/logger.py
@@ -74,7 +74,7 @@ class MorituriLogger(result.Logger):
         lines.append("  MusicBrainz Disc ID: %s" %
                      ripResult. table.musicbrainz_discid)
         lines.append("  MusicBrainz lookup url: %s" %
-                     ripResult. table.getMusicBrainzSubmitURL())
+                     ripResult. table.musicbrainz_submit_url)
         lines.append("")
 
         # TOC section

--- a/morituri/test/test_image_image.py
+++ b/morituri/test/test_image_image.py
@@ -46,7 +46,7 @@ class TrackSingleTestCase(tcommon.TestCase):
         self.assertEquals(self.image.table.getTrackLength(4), 4)
 
     def testCDDB(self):
-        self.assertEquals(self.image.table.getCDDBDiscId(), "08000004")
+        self.assertEquals(self.image.table.cddb_discid, "08000004")
 
     def testAccurateRip(self):
         self.assertEquals(self.image.table.getAccurateRipIds(), (
@@ -78,7 +78,7 @@ class TrackSeparateTestCase(tcommon.TestCase):
         self.assertEquals(self.image.table.getTrackLength(4), 10)
 
     def testCDDB(self):
-        self.assertEquals(self.image.table.getCDDBDiscId(), "08000004")
+        self.assertEquals(self.image.table.cddb_discid, "08000004")
 
     def testAccurateRip(self):
         self.assertEquals(self.image.table.getAccurateRipIds(), (

--- a/morituri/test/test_image_image.py
+++ b/morituri/test/test_image_image.py
@@ -49,7 +49,7 @@ class TrackSingleTestCase(tcommon.TestCase):
         self.assertEquals(self.image.table.cddb_discid, "08000004")
 
     def testAccurateRip(self):
-        self.assertEquals(self.image.table.getAccurateRipIds(), (
+        self.assertEquals(self.image.table.accuraterip_ids, (
             "00000016", "0000005b"))
 
 
@@ -81,5 +81,5 @@ class TrackSeparateTestCase(tcommon.TestCase):
         self.assertEquals(self.image.table.cddb_discid, "08000004")
 
     def testAccurateRip(self):
-        self.assertEquals(self.image.table.getAccurateRipIds(), (
+        self.assertEquals(self.image.table.accuraterip_ids, (
             "00000064", "00000191"))

--- a/morituri/test/test_image_table.py
+++ b/morituri/test/test_image_table.py
@@ -58,7 +58,7 @@ class LadyhawkeTestCase(tcommon.TestCase):
         # 177832&tracks=12&id=KnpGsLhvH.lPrNc1PBL21lb9Bg4-
         # however, not (yet) in musicbrainz database
 
-        self.assertEquals(self.table.getMusicBrainzDiscId(),
+        self.assertEquals(self.table.musicbrainz_discid,
             "KnpGsLhvH.lPrNc1PBL21lb9Bg4-")
 
     def testAccurateRip(self):
@@ -94,7 +94,7 @@ class MusicBrainzTestCase(tcommon.TestCase):
         self.failUnless(self.table.hasTOC())
 
     def testMusicBrainz(self):
-        self.assertEquals(self.table.getMusicBrainzDiscId(),
+        self.assertEquals(self.table.musicbrainz_discid,
             '49HHV7Eb8UKF3aQiNmu1GR8vKTY-')
 
 

--- a/morituri/test/test_image_table.py
+++ b/morituri/test/test_image_table.py
@@ -49,7 +49,7 @@ class LadyhawkeTestCase(tcommon.TestCase):
         self.assertEquals(self.table.tracks[0].getPregap(), 0)
 
     def testCDDB(self):
-        self.assertEquals(self.table.getCDDBDiscId(), "c60af50d")
+        self.assertEquals(self.table.cddb_discid, "c60af50d")
 
     def testMusicBrainz(self):
         # output from mb-submit-disc:

--- a/morituri/test/test_image_table.py
+++ b/morituri/test/test_image_table.py
@@ -46,7 +46,7 @@ class LadyhawkeTestCase(tcommon.TestCase):
         self.table.leadout = 210385
 
         self.failUnless(self.table.hasTOC())
-        self.assertEquals(self.table.tracks[0].getPregap(), 0)
+        self.assertEquals(self.table.tracks[0].pregap, 0)
 
     def testCDDB(self):
         self.assertEquals(self.table.cddb_discid, "c60af50d")
@@ -113,5 +113,5 @@ class PregapTestCase(tcommon.TestCase):
         t[1].index(0, offsets[1] - 200)
 
     def testPreGap(self):
-        self.assertEquals(self.table.tracks[0].getPregap(), 0)
-        self.assertEquals(self.table.tracks[1].getPregap(), 200)
+        self.assertEquals(self.table.tracks[0].pregap, 0)
+        self.assertEquals(self.table.tracks[1].pregap, 200)

--- a/morituri/test/test_image_table.py
+++ b/morituri/test/test_image_table.py
@@ -64,7 +64,7 @@ class LadyhawkeTestCase(tcommon.TestCase):
     def testAccurateRip(self):
         self.assertEquals(self.table.getAccurateRipIds(), (
             "0013bd5a", "00b8d489"))
-        self.assertEquals(self.table.getAccurateRipURL(),
+        self.assertEquals(self.table.accuraterip_url,
         "http://www.accuraterip.com/accuraterip/a/5/d/"
         "dBAR-012-0013bd5a-00b8d489-c60af50d.bin")
 

--- a/morituri/test/test_image_table.py
+++ b/morituri/test/test_image_table.py
@@ -62,7 +62,7 @@ class LadyhawkeTestCase(tcommon.TestCase):
             "KnpGsLhvH.lPrNc1PBL21lb9Bg4-")
 
     def testAccurateRip(self):
-        self.assertEquals(self.table.getAccurateRipIds(), (
+        self.assertEquals(self.table.accuraterip_ids, (
             "0013bd5a", "00b8d489"))
         self.assertEquals(self.table.accuraterip_url,
         "http://www.accuraterip.com/accuraterip/a/5/d/"

--- a/morituri/test/test_image_toc.py
+++ b/morituri/test/test_image_toc.py
@@ -92,7 +92,7 @@ class CureTestCase(common.TestCase):
         common.diffStrings(ref, cue)
 
         # we verify it because it has failed in readdisc in the past
-        self.assertEquals(self.toc.table.getAccurateRipURL(),
+        self.assertEquals(self.toc.table.accuraterip_url,
             'http://www.accuraterip.com/accuraterip/'
             '3/c/4/dBAR-013-0019d4c3-00fe8924-b90c650d.bin')
 
@@ -172,7 +172,7 @@ class BlocTestCase(common.TestCase):
     def testAccurateRip(self):
         # we verify it because it has failed in readdisc in the past
         # self.toc.table.absolutize()
-        self.assertEquals(self.toc.table.getAccurateRipURL(),
+        self.assertEquals(self.toc.table.accuraterip_url,
             'http://www.accuraterip.com/accuraterip/'
             'e/d/2/dBAR-013-001af2de-0105994e-ad0be00d.bin')
 

--- a/morituri/test/test_image_toc.py
+++ b/morituri/test/test_image_toc.py
@@ -37,12 +37,12 @@ class CureTestCase(common.TestCase):
         # FIXME: cdrdao seems to get length of FILE 1 frame too many,
         # and START value one frame less
         t = self.toc.table.tracks[1]
-        self.assertEquals(t.getIndex(0).relative, 28245)
-        self.assertEquals(t.getIndex(1).relative, 28324)
+        self.assertEquals(t.indexes[0].relative, 28245)
+        self.assertEquals(t.indexes[1].relative, 28324)
 
     def _getIndex(self, t, i):
         track = self.toc.table.tracks[t - 1]
-        return track.getIndex(i)
+        return track.indexes[i]
 
     def _assertAbsolute(self, t, i, value):
         index = self._getIndex(t, i)
@@ -130,24 +130,24 @@ class BlocTestCase(common.TestCase):
 
     def testIndexes(self):
         track01 = self.toc.table.tracks[0]
-        index00 = track01.getIndex(0)
+        index00 = track01.indexes[0]
         self.assertEquals(index00.absolute, 0)
         self.assertEquals(index00.relative, 0)
         self.assertEquals(index00.counter, 0)
 
-        index01 = track01.getIndex(1)
+        index01 = track01.indexes[1]
         self.assertEquals(index01.absolute, 15220)
         self.assertEquals(index01.relative, 0)
         self.assertEquals(index01.counter, 1)
 
         track05 = self.toc.table.tracks[4]
 
-        index00 = track05.getIndex(0)
+        index00 = track05.indexes[0]
         self.assertEquals(index00.absolute, 84070)
         self.assertEquals(index00.relative, 68850)
         self.assertEquals(index00.counter, 1)
 
-        index01 = track05.getIndex(1)
+        index01 = track05.indexes[1]
         self.assertEquals(index01.absolute, 84142)
         self.assertEquals(index01.relative, 68922)
         self.assertEquals(index01.counter, 1)
@@ -354,13 +354,13 @@ class StrokesTestCase(common.TestCase):
 
     def testIndexes(self):
         t = self.toc.table.tracks[0]
-        i0 = t.getIndex(0)
+        i0 = t.indexes[0]
         self.assertEquals(i0.relative, 0)
         self.assertEquals(i0.absolute, 0)
         self.assertEquals(i0.counter, 0)
         self.assertEquals(i0.path, None)
 
-        i1 = t.getIndex(1)
+        i1 = t.indexes[1]
         self.assertEquals(i1.relative, 0)
         self.assertEquals(i1.absolute, 1)
         self.assertEquals(i1.counter, 1)
@@ -418,13 +418,13 @@ class SurferRosaTestCase(common.TestCase):
         t = self.toc.table.tracks[0]
         self.assertEquals(len(t.indexes), 2)
 
-        i0 = t.getIndex(0)
+        i0 = t.indexes[0]
         self.assertEquals(i0.relative, 0)
         self.assertEquals(i0.absolute, 0)
         self.assertEquals(i0.path, None)
         self.assertEquals(i0.counter, 0)
 
-        i1 = t.getIndex(1)
+        i1 = t.indexes[1]
         self.assertEquals(i1.relative, 0)
         self.assertEquals(i1.absolute, 32)
         self.assertEquals(i1.path, 'data.wav')
@@ -436,10 +436,10 @@ class SurferRosaTestCase(common.TestCase):
         self.assertEquals(len(t.indexes), 2)
 
         # 32 frames of silence, and 1483 seconds of data.wav
-        self.assertEquals(t.getIndex(1).relative, 111225)
-        self.assertEquals(t.getIndex(1).absolute, 111257)
-        self.assertEquals(t.getIndex(2).relative, 111225 + 3370)
-        self.assertEquals(t.getIndex(2).absolute, 111257 + 3370)
+        self.assertEquals(t.indexes[1].relative, 111225)
+        self.assertEquals(t.indexes[1].absolute, 111257)
+        self.assertEquals(t.indexes[2].relative, 111225 + 3370)
+        self.assertEquals(t.indexes[2].absolute, 111257 + 3370)
 
 #        print self.toc.table.cue()
 

--- a/morituri/test/test_image_toc.py
+++ b/morituri/test/test_image_toc.py
@@ -167,7 +167,7 @@ class BlocTestCase(common.TestCase):
         # ad0be00d 13 15370 35019 51532 69190 84292 96826 112527 132448
         # 148595 168072 185539 203331 222103 3244
 
-        self.assertEquals(self.toc.table.getCDDBDiscId(), 'ad0be00d')
+        self.assertEquals(self.toc.table.cddb_discid, 'ad0be00d')
 
     def testAccurateRip(self):
         # we verify it because it has failed in readdisc in the past
@@ -221,7 +221,7 @@ class LadyhawkeTestCase(common.TestCase):
 
     def testCDDBId(self):
         #self.toc.table.absolutize()
-        self.assertEquals(self.toc.table.getCDDBDiscId(), 'c60af50d')
+        self.assertEquals(self.toc.table.cddb_discid, 'c60af50d')
         # output from cd-discid:
         # c60af50d 13 150 15687 31841 51016 66616 81352 99559 116070 133243
         # 149997 161710 177832 207256 2807
@@ -270,7 +270,7 @@ class CapitalMergeTestCase(common.TestCase):
 
     def testCDDBId(self):
         #self.table.absolutize()
-        self.assertEquals(self.table.getCDDBDiscId(), 'b910140c')
+        self.assertEquals(self.table.cddb_discid, 'b910140c')
         # output from cd-discid:
         # b910140c 12 24320 44855 64090 77885 88095 104020 118245 129255 141765
         # 164487 181780 209250 4440
@@ -337,7 +337,7 @@ class TOTBLTestCase(common.TestCase):
 
     def testCDDBId(self):
         #self.toc.table.absolutize()
-        self.assertEquals(self.toc.table.getCDDBDiscId(), '810b7b0b')
+        self.assertEquals(self.toc.table.cddb_discid, '810b7b0b')
 
 
 # The Strokes - Someday has a 1 frame SILENCE marked as such in toc

--- a/morituri/test/test_image_toc.py
+++ b/morituri/test/test_image_toc.py
@@ -229,7 +229,7 @@ class LadyhawkeTestCase(common.TestCase):
     def testMusicBrainz(self):
         self.assertEquals(self.toc.table.musicbrainz_discid,
             "KnpGsLhvH.lPrNc1PBL21lb9Bg4-")
-        self.assertEquals(self.toc.table.getMusicBrainzSubmitURL(),
+        self.assertEquals(self.toc.table.musicbrainz_submit_url,
             "https://musicbrainz.org/cdtoc/attach?toc="
             "1+12+195856+150+15687+31841+51016+66616+81352+99559+"
             "116070+133243+149997+161710+177832&"

--- a/morituri/test/test_image_toc.py
+++ b/morituri/test/test_image_toc.py
@@ -227,7 +227,7 @@ class LadyhawkeTestCase(common.TestCase):
         # 149997 161710 177832 207256 2807
 
     def testMusicBrainz(self):
-        self.assertEquals(self.toc.table.getMusicBrainzDiscId(),
+        self.assertEquals(self.toc.table.musicbrainz_discid,
             "KnpGsLhvH.lPrNc1PBL21lb9Bg4-")
         self.assertEquals(self.toc.table.getMusicBrainzSubmitURL(),
             "https://musicbrainz.org/cdtoc/attach?toc="
@@ -279,7 +279,7 @@ class CapitalMergeTestCase(common.TestCase):
         # URL to submit: https://musicbrainz.org/cdtoc/attach?toc=1+11+
         # 197850+24320+44855+64090+77885+88095+104020+118245+129255+141765+
         # 164487+181780&tracks=11&id=MAj3xXf6QMy7G.BIFOyHyq4MySE-
-        self.assertEquals(self.table.getMusicBrainzDiscId(),
+        self.assertEquals(self.table.musicbrainz_discid,
             "MAj3xXf6QMy7G.BIFOyHyq4MySE-")
 
     def testDuration(self):


### PR DESCRIPTION
- introduces `common.lazy_property` decorator: calculate return value for attribute with method once, then override object property to return only the result value henceforth.
- uses `@lazy_property` decorator in all appropriate places in `images`.
- remove `Track.getIndex()` in favour of `Track.indexes` lookups everywhere.