### PR TITLE
Persist False value for defeats_cache correctly

### DIFF
--- a/morituri/common/config.py
+++ b/morituri/common/config.py
@@ -113,7 +113,7 @@ class Config:
         section = self._findDriveSection(vendor, model, release)
 
         try:
-            return bool(self._parser.get(section, 'defeats_cache'))
+            return self._parser.get(section, 'defeats_cache') == 'True'
         except ConfigParser.NoOptionError:
             raise KeyError("Could not find defeats_cache for %s/%s/%s" % (
                 vendor, model, release))

--- a/morituri/test/test_common_config.py
+++ b/morituri/test/test_common_config.py
@@ -9,7 +9,7 @@ from morituri.common import config
 from morituri.test import common as tcommon
 
 
-class OffsetTestCase(tcommon.TestCase):
+class ConfigTestCase(tcommon.TestCase):
 
     def setUp(self):
         fd, self._path = tempfile.mkstemp(suffix=u'.morituri.test.config')
@@ -50,3 +50,19 @@ class OffsetTestCase(tcommon.TestCase):
         offset = self._config.getReadOffset(
             'Slimtype', 'eSAU208   2     ', 'ML03')
         self.assertEquals(offset, 6)
+
+    def testDefeatsCache(self):
+        self.assertRaises(KeyError, self._config.getDefeatsCache,
+            'PLEXTOR ', 'DVDR   PX-L890SA', '1.05')
+
+        self._config.setDefeatsCache(
+            'PLEXTOR ', 'DVDR   PX-L890SA', '1.05', False)
+        defeats = self._config.getDefeatsCache(
+            'PLEXTOR ', 'DVDR   PX-L890SA', '1.05')
+        self.assertEquals(defeats, False)
+
+        self._config.setDefeatsCache(
+            'PLEXTOR ', 'DVDR   PX-L890SA', '1.05', True)
+        defeats = self._config.getDefeatsCache(
+            'PLEXTOR ', 'DVDR   PX-L890SA', '1.05')
+        self.assertEquals(defeats, True)


### PR DESCRIPTION
If `cdparanoia` can't work around the audio caching of a drive, `defeats_cache = False` is written to the config.  However, when it is read back the string `'False'` ends up being converted to `True` (as it is not an empty string).

This PR corrects the behaviour when reading the value back and adds tests to make sure that both `True` and `False` can be correctly retrieved from the config.

What I'm not sure about is the impact of this bug - does the incorrectly retrieved value have an impact on rips completed?  I wonder why it didn't get noticed before (unless I'm reading git blame wrong, it looks like it might have been in morituri since Dec 2012) - is it unusual for `cdparanoia` to be unable to work around the audio caching behaviour of a drive?