### PR TITLE
Add gstreamer-less flac encoder and tagging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 
     # Testing dependencies
     - sudo apt-get install -qq gstreamer0.10-tools python-gst0.10
-    - sudo pip install twisted
+    - sudo pip install twisted mutagen
 
     # Build bundled C utils
     - cd src

--- a/morituri/command/debug.py
+++ b/morituri/command/debug.py
@@ -187,7 +187,7 @@ class Encode(BaseCommand):
         logger.debug('Encoding %s to %s',
             fromPath.encode('utf-8'),
             toPath.encode('utf-8'))
-        encodetask = encode.EncodeTask(fromPath, toPath, profile)
+        encodetask = encode.FlacEncodeTask(fromPath, toPath)
 
         runner.run(encodetask)
 

--- a/morituri/common/encode.py
+++ b/morituri/common/encode.py
@@ -31,6 +31,7 @@ from morituri.common import task as ctask
 
 from morituri.extern.task import task, gstreamer
 from morituri.program import sox
+from morituri.program import flac
 
 import logging
 logger = logging.getLogger(__name__)
@@ -180,6 +181,23 @@ class SoxPeakTask(task.Task):
 
     def _sox_peak(self):
         self.peak = sox.peak_level(self.track_path)
+        self.stop()
+
+class FlacEncodeTask(task.Task):
+    description = 'Encoding to FLAC'
+
+    def __init__(self, track_path, track_out_path, what="track"):
+        self.track_path = track_path
+        self.track_out_path = track_out_path
+        self.new_path = None
+        self.description = 'Encoding %s to FLAC' % what
+
+    def start(self, runner):
+        task.Task.start(self, runner)
+        self.schedule(0.0, self._flac_encode)
+
+    def _flac_encode(self):
+        self.new_path = flac.encode(self.track_path, self.track_out_path)
         self.stop()
 
 class EncodeTask(ctask.GstPipelineTask):

--- a/morituri/common/program.py
+++ b/morituri/common/program.py
@@ -450,58 +450,29 @@ class Program:
                 # htoa defaults to disc's artist
                 title = 'Hidden Track One Audio'
 
-        # here to avoid import gst eating our options
-        import gst
+        tags = {}
 
-        ret = gst.TagList()
-
-        # gst-python 0.10.15.1 does not handle unicode -> utf8 string
-        # conversion
-        # see http://bugzilla.gnome.org/show_bug.cgi?id=584445
         if self.metadata and not self.metadata.various:
-            ret["album-artist"] = albumArtist.encode('utf-8')
-        ret[gst.TAG_ARTIST] = trackArtist.encode('utf-8')
-        ret[gst.TAG_TITLE] = title.encode('utf-8')
-        ret[gst.TAG_ALBUM] = disc.encode('utf-8')
+            tags['ALBUMARTIST'] = albumArtist.encode('utf-8')
+        tags['ARTIST'] = trackArtist.encode('utf-8')
+        tags['TITLE'] = title.encode('utf-8')
+        tags['DISC'] = disc.encode('utf-8')
 
-        # gst-python 0.10.15.1 does not handle tags that are UINT
-        # see gst-python commit 26fa6dd184a8d6d103eaddf5f12bd7e5144413fb
-        # FIXME: no way to compare against 'master' version after 0.10.15
-        if gst.pygst_version >= (0, 10, 15):
-            ret[gst.TAG_TRACK_NUMBER] = number
+        tags['TRACKNUMBER'] = u'%s' % number
+
         if self.metadata:
-            # works, but not sure we want this
-            # if gst.pygst_version >= (0, 10, 15):
-            #     ret[gst.TAG_TRACK_COUNT] = len(self.metadata.tracks)
-            # hack to get a GstDate which we cannot instantiate directly in
-            # 0.10.15.1
-            # FIXME: The dates are strings and must have the format 'YYYY',
-            # 'YYYY-MM' or 'YYYY-MM-DD'.
-            # GstDate expects a full date, so default to
-            # Jan and 1st if MM and DD are missing
-            date = self.metadata.release
-            if date:
-                logger.debug('Converting release date %r to structure', date)
-                if len(date) == 4:
-                    date += '-01'
-                if len(date) == 7:
-                    date += '-01'
+            tags['DATE'] = self.metadata.release
 
-                s = gst.structure_from_string('hi,date=(GstDate)%s' %
-                    str(date))
-                ret[gst.TAG_DATE] = s['date']
-
-            # no musicbrainz info for htoa tracks
             if number > 0:
-                ret["musicbrainz-trackid"] = mbidTrack
-                ret["musicbrainz-artistid"] = mbidTrackArtist
-                ret["musicbrainz-albumid"] = mbidAlbum
-                ret["musicbrainz-albumartistid"] = mbidTrackAlbum
-                ret["musicbrainz-discid"] = mbDiscId
+                tags['musicbrainz-trackid'] = mbidTrack
+                tags['musicbrainz-artistid'] = mbidTrackArtist
+                tags['musicbrainz-albumid'] = mbidAlbum
+                tags['musicbrainz-albumartistid'] = mbidTrackAlbum
+                tags['musicbrainz-discid'] = mbDiscId
 
-        # FIXME: gst.TAG_ISRC
+        # TODO/FIXME: ISRC tag
 
-        return ret
+        return tags
 
     def getHTOA(self):
         """

--- a/morituri/common/program.py
+++ b/morituri/common/program.py
@@ -453,10 +453,10 @@ class Program:
         tags = {}
 
         if self.metadata and not self.metadata.various:
-            tags['ALBUMARTIST'] = albumArtist.encode('utf-8')
-        tags['ARTIST'] = trackArtist.encode('utf-8')
-        tags['TITLE'] = title.encode('utf-8')
-        tags['DISC'] = disc.encode('utf-8')
+            tags['ALBUMARTIST'] = albumArtist
+        tags['ARTIST'] = trackArtist
+        tags['TITLE'] = title
+        tags['ALBUM'] = disc
 
         tags['TRACKNUMBER'] = u'%s' % number
 
@@ -464,11 +464,11 @@ class Program:
             tags['DATE'] = self.metadata.release
 
             if number > 0:
-                tags['musicbrainz-trackid'] = mbidTrack
-                tags['musicbrainz-artistid'] = mbidTrackArtist
-                tags['musicbrainz-albumid'] = mbidAlbum
-                tags['musicbrainz-albumartistid'] = mbidTrackAlbum
-                tags['musicbrainz-discid'] = mbDiscId
+                tags['MUSICBRAINZ_TRACKID'] = mbidTrack
+                tags['MUSICBRAINZ_ARTISTID'] = mbidTrackArtist
+                tags['MUSICBRAINZ_ALBUMID'] = mbidAlbum
+                tags['MUSICBRAINZ_ALBUMARTISTID'] = mbidTrackAlbum
+                tags['MUSICBRAINZ_DISCID'] = mbDiscId
 
         # TODO/FIXME: ISRC tag
 

--- a/morituri/image/image.py
+++ b/morituri/image/image.py
@@ -240,8 +240,8 @@ class ImageEncodeTask(task.MultiSeparateTask):
             root, ext = os.path.splitext(os.path.basename(path))
             outpath = os.path.join(outdir, root + '.' + profile.extension)
             logger.debug('schedule encode to %r', outpath)
-            taskk = encode.EncodeTask(path, os.path.join(outdir,
-                root + '.' + profile.extension), profile)
+            taskk = encode.EncodeTaskFlac(path, os.path.join(outdir,
+                root + '.' + profile.extension))
             self.addTask(taskk)
 
         try:

--- a/morituri/program/cdparanoia.py
+++ b/morituri/program/cdparanoia.py
@@ -499,6 +499,9 @@ class ReadVerifyTrackTask(task.MultiSeparateTask):
         self.tasks.append(checksum.CRC32Task(tmppath))
         self.tasks.append(encode.SoxPeakTask(tmppath))
 
+        # TODO: Move tagging outside of cdparanoia
+        self.tasks.append(encode.TaggingTask(tmpoutpath, taglist))
+
         self.checksum = None
 
     def stop(self):

--- a/morituri/program/cdparanoia.py
+++ b/morituri/program/cdparanoia.py
@@ -490,10 +490,13 @@ class ReadVerifyTrackTask(task.MultiSeparateTask):
         # here to avoid import gst eating our options
         from morituri.common import encode
 
-        self.tasks.append(encode.EncodeTask(tmppath, tmpoutpath, profile,
-            taglist=taglist, what=what))
+        self.tasks.append(encode.FlacEncodeTask(tmppath, tmpoutpath))
+
+        # MerlijnWajer: XXX: We run the CRC32Task on the wav file, because it's
+        # in general stupid to run the CRC32 on the flac file since it already
+        # has --verify. We should just get rid of this CRC32 step.
         # make sure our encoding is accurate
-        self.tasks.append(checksum.CRC32Task(tmpoutpath))
+        self.tasks.append(checksum.CRC32Task(tmppath))
         self.tasks.append(encode.SoxPeakTask(tmppath))
 
         self.checksum = None

--- a/morituri/program/flac.py
+++ b/morituri/program/flac.py
@@ -3,16 +3,15 @@ from subprocess import check_call, CalledProcessError
 import logging
 logger = logging.getLogger(__name__)
 
-FLAC = 'flac'
-
-
 def encode(infile, outfile):
     """
     Encodes infile to outfile, with flac.
     Uses '-f' because morituri already creates the file.
     """
     try:
-        check_call(['flac', '--totally-silent', '--verify', '-o', outfile,
+        # TODO: Replace with Popen so that we can catch stderr and write it to
+        # logging
+        check_call(['flac', '--silent', '--verify', '-o', outfile,
                     '-f', infile])
     except CalledProcessError:
         logger.exception('flac failed')

--- a/morituri/program/flac.py
+++ b/morituri/program/flac.py
@@ -1,0 +1,19 @@
+from subprocess import check_call, CalledProcessError
+
+import logging
+logger = logging.getLogger(__name__)
+
+FLAC = 'flac'
+
+
+def encode(infile, outfile):
+    """
+    Encodes infile to outfile, with flac.
+    Uses '-f' because morituri already creates the file.
+    """
+    try:
+        check_call(['flac', '--totally-silent', '--verify', '-o', outfile,
+                    '-f', infile])
+    except CalledProcessError:
+        logger.exception('flac failed')
+        raise


### PR DESCRIPTION
Two commits - the first commit perform the FLAC encoding using the Xiph.org 'flac' program. Because whipper/morituri's gstreamer 'encoding' code also tagged - the second commit adds tagging using mutagen.

Note that these two commits mostly do not remove gstreamer code (the tag one does, however). We need to add an equivalent of the CRC32 task (or simply remove it?). Once we have that in place, as far as I am concerned, we can start removing *ALL* the gstreamer code.

See https://github.com/JoeLametta/whipper/issues/29