### PR TITLE
program: do not fetch 4 times musicbrainz metadata

### DIFF
--- a/morituri/common/program.py
+++ b/morituri/common/program.py
@@ -305,6 +305,7 @@ class Program:
                 metadatas = mbngs.musicbrainz(mbdiscid,
                     country=country,
                     record=self._record)
+                break
             except mbngs.NotFoundException, e:
                 break
             except musicbrainzngs.NetworkError, e:


### PR DESCRIPTION
It currently calls 4x times the metadata everytime so this quick fix address that issue.

Nevertheless, it might be wise to remove the clumsy 4 attempts in case of http error, and maybe simplify the exception and logging management associated with `mbngs.musicbrainz()`.