### PR TITLE
Disambiguate on release

### DIFF
--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -242,7 +242,7 @@ class Program:
 
         # when disambiguating, use catalogNumber then barcode
         if disambiguate:
-            templateParts = list(os.path.split(template))
+            templateParts = template.split(os.sep)
             # Find the section of the template with the release name
             for i, part in enumerate(templateParts):
                 if "%d" in part:

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -250,6 +250,7 @@ class Program:
                         templateParts[i] += ' (%s)' % self.metadata.catalogNumber
                     elif self.metadata.barcode:
                         templateParts[i] += ' (%s)' % self.metadata.barcode
+                    break
             template = os.path.join(*templateParts)
             logger.debug('Disambiguated template to %r' % template)
 

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -243,10 +243,13 @@ class Program:
         # when disambiguating, use catalogNumber then barcode
         if disambiguate:
             templateParts = list(os.path.split(template))
-            if self.metadata.catalogNumber:
-                templateParts[-2] += ' (%s)' % self.metadata.catalogNumber
-            elif self.metadata.barcode:
-                templateParts[-2] += ' (%s)' % self.metadata.barcode
+            # Find the section of the template with the release name
+            for i, part in enumerate(templateParts):
+                if "%d" in part:
+                    if self.metadata.catalogNumber:
+                        templateParts[i] += ' (%s)' % self.metadata.catalogNumber
+                    elif self.metadata.barcode:
+                        templateParts[i] += ' (%s)' % self.metadata.barcode
             template = os.path.join(*templateParts)
             logger.debug('Disambiguated template to %r' % template)
 

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -170,6 +170,14 @@ class Program:
     def saveRipResult(self):
         self._presult.persist()
 
+    def addDisambiguation(self, template_part, metadata):
+        "Add disambiguation to template path part string."
+        if metadata.catalogNumber:
+            template_part += ' (%s)' % metadata.catalogNumber
+        elif metadata.barcode:
+            template_part += ' (%s)' % metadata.barcode
+        return template_part
+
     def getPath(self, outdir, template, mbdiscid, i, disambiguate=False):
         """
         Based on the template, get a complete path for the given track,
@@ -246,17 +254,11 @@ class Program:
             # Find the section of the template with the release name
             for i, part in enumerate(templateParts):
                 if "%d" in part:
-                    if self.metadata.catalogNumber:
-                        templateParts[i] += ' (%s)' % self.metadata.catalogNumber
-                    elif self.metadata.barcode:
-                        templateParts[i] += ' (%s)' % self.metadata.barcode
+                    templateParts[i] = self.addDisambiguation(part, self.metadata)
                     break
             else:
                 # No parts of the template contain the release
-                if self.metadata.catalogNumber:
-                    templateParts[-1] += ' (%s)' % self.metadata.catalogNumber
-                elif self.metadata.barcode:
-                    templateParts[-1] += ' (%s)' % self.metadata.barcode
+                templateParts[-1] = self.addDisambiguation(templateParts[-1], self.metadata)
             template = os.path.join(*templateParts)
             logger.debug('Disambiguated template to %r' % template)
 

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -251,6 +251,12 @@ class Program:
                     elif self.metadata.barcode:
                         templateParts[i] += ' (%s)' % self.metadata.barcode
                     break
+            else:
+                # No parts of the template contain the release
+                if self.metadata.catalogNumber:
+                    templateParts[-1] += ' (%s)' % self.metadata.catalogNumber
+                elif self.metadata.barcode:
+                    templateParts[-1] += ' (%s)' % self.metadata.barcode
             template = os.path.join(*templateParts)
             logger.debug('Disambiguated template to %r' % template)
 

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -254,11 +254,11 @@ class Program:
             # Find the section of the template with the release name
             for i, part in enumerate(templateParts):
                 if "%d" in part:
-                    templateParts[i] = self.addDisambiguation(part, self.metadata)
+                    templateParts[i] = self.addDisambiguation(part, self.metadata)  # noqa: E501
                     break
             else:
                 # No parts of the template contain the release
-                templateParts[-1] = self.addDisambiguation(templateParts[-1], self.metadata)
+                templateParts[-1] = self.addDisambiguation(templateParts[-1], self.metadata)  # noqa: E501
             template = os.path.join(*templateParts)
             logger.debug('Disambiguated template to %r' % template)
 

--- a/whipper/test/test_common_program.py
+++ b/whipper/test/test_common_program.py
@@ -179,3 +179,25 @@ class PathTestCase(unittest.TestCase):
         for template, expected_path in templates.iteritems():
             path = prog.getPath(u'/tmp', template, 'mbdiscid', 0, disambiguate=True)
             self.assertEquals(path, u'/tmp/' + expected_path)
+
+    def testAddDisambiguationUnitTest(self):
+        """Unit test for Program.addDisambiguation()."""
+        prog = program.Program(config.Config())
+        md = mbngs.DiscMetadata()
+
+        # No relevant disambiguation metadata
+        self.assertEquals(
+            prog.addDisambiguation(u'Test', md),
+            u'Test')
+
+        # Only barcode available
+        md.barcode = '033651008927'
+        self.assertEquals(
+            prog.addDisambiguation(u'Test', md),
+            u'Test (033651008927)')
+
+        # Both catalog number and barcode available
+        md.catalogNumber = 'RHR CD 89'
+        self.assertEquals(
+            prog.addDisambiguation(u'Test', md),
+            u'Test (RHR CD 89)')

--- a/whipper/test/test_common_program.py
+++ b/whipper/test/test_common_program.py
@@ -143,3 +143,19 @@ class PathTestCase(unittest.TestCase):
         for template, expected_path in templates.iteritems():
             path = prog.getPath(u'/tmp', template, 'mbdiscid', 0, disambiguate=True)
             self.assertEquals(path, u'/tmp/' + expected_path)
+
+    def testDisambiguateOnReleaseOnlyOnce(self):
+        """Test that disambiguation gets added only once."""
+        prog = program.Program(config.Config())
+        md = mbngs.DiscMetadata()
+        md.artist = 'Guy Davis'
+        md.sortName = 'Davis, Guy'
+        md.title = 'Call Down the Thunder'
+        md.release = '1996'
+        md.catalogNumber = 'RHR CD 89'
+        prog.metadata = md
+        template = u'%A/%d - %y/%d/%d'
+
+        path = prog.getPath(u'/tmp', template, 'mbdiscid', 0, disambiguate=True)
+        self.assertEquals(path,
+            u'/tmp/Guy Davis/Call Down the Thunder - 1996 (RHR CD 89)/Call Down the Thunder/Call Down the Thunder')

--- a/whipper/test/test_common_program.py
+++ b/whipper/test/test_common_program.py
@@ -119,3 +119,21 @@ class PathTestCase(unittest.TestCase):
         path = prog.getPath(u'/tmp', u'%A/%d', 'mbdiscid', 0)
         self.assertEquals(path,
                           u'/tmp/Jeff Buckley/Grace')
+
+    def testDisambiguateOnRelease(self):
+        """Test that disambiguation gets placed in the same part of the path as the release name.
+
+        See https://github.com/JoeLametta/whipper/issues/127"""
+        prog = program.Program(config.Config())
+        md = mbngs.DiscMetadata()
+        md.artist = 'Guy Davis'
+        md.sortName = 'Davis, Guy'
+        md.title = 'Call Down the Thunder'
+        md.release = '1996'
+        md.catalogNumber = 'RHR CD 89'
+        template = u'%A/%d - %y'
+        prog.metadata = md
+
+        path = prog.getPath(u'/tmp', template, 'mbdiscid', 0, disambiguate=True)
+        self.assertEquals(path,
+                          u'/tmp/Guy Davis/Call Down the Thunder - 1996 (RHR CD 89)')

--- a/whipper/test/test_common_program.py
+++ b/whipper/test/test_common_program.py
@@ -131,9 +131,15 @@ class PathTestCase(unittest.TestCase):
         md.title = 'Call Down the Thunder'
         md.release = '1996'
         md.catalogNumber = 'RHR CD 89'
-        template = u'%A/%d - %y'
         prog.metadata = md
+        templates = {
+            u'%A/%d - %y': u'Guy Davis/Call Down the Thunder - 1996 (RHR CD 89)',
+            u'%A - %d - %y': u'Guy Davis - Call Down the Thunder - 1996 (RHR CD 89)',
+            u'%A/%y/%d': u'Guy Davis/1996/Call Down the Thunder (RHR CD 89)',
+            u'%y/%d/%A': u'1996/Call Down the Thunder (RHR CD 89)/Guy Davis',
+            u'%d/%A/%y': u'Call Down the Thunder (RHR CD 89)/Guy Davis/1996',
+        }
 
-        path = prog.getPath(u'/tmp', template, 'mbdiscid', 0, disambiguate=True)
-        self.assertEquals(path,
-                          u'/tmp/Guy Davis/Call Down the Thunder - 1996 (RHR CD 89)')
+        for template, expected_path in templates.iteritems():
+            path = prog.getPath(u'/tmp', template, 'mbdiscid', 0, disambiguate=True)
+            self.assertEquals(path, u'/tmp/' + expected_path)

--- a/whipper/test/test_common_program.py
+++ b/whipper/test/test_common_program.py
@@ -121,7 +121,8 @@ class PathTestCase(unittest.TestCase):
                           u'/tmp/Jeff Buckley/Grace')
 
     def testDisambiguateOnRelease(self):
-        """Test that disambiguation gets placed in the same part of the path as the release name.
+        """Test that disambiguation gets placed in the same part of the path
+        as the release name.
 
         See https://github.com/JoeLametta/whipper/issues/127"""
         prog = program.Program(config.Config())
@@ -133,15 +134,15 @@ class PathTestCase(unittest.TestCase):
         md.catalogNumber = 'RHR CD 89'
         prog.metadata = md
         templates = {
-            u'%A/%d - %y': u'Guy Davis/Call Down the Thunder - 1996 (RHR CD 89)',
-            u'%A - %d - %y': u'Guy Davis - Call Down the Thunder - 1996 (RHR CD 89)',
+            u'%A/%d - %y': u'Guy Davis/Call Down the Thunder - 1996 (RHR CD 89)',  # noqa: E501
+            u'%A - %d - %y': u'Guy Davis - Call Down the Thunder - 1996 (RHR CD 89)',  # noqa: E501
             u'%A/%y/%d': u'Guy Davis/1996/Call Down the Thunder (RHR CD 89)',
             u'%y/%d/%A': u'1996/Call Down the Thunder (RHR CD 89)/Guy Davis',
             u'%d/%A/%y': u'Call Down the Thunder (RHR CD 89)/Guy Davis/1996',
         }
 
         for template, expected_path in templates.iteritems():
-            path = prog.getPath(u'/tmp', template, 'mbdiscid', 0, disambiguate=True)
+            path = prog.getPath(u'/tmp', template, 'mbdiscid', 0, disambiguate=True)  # noqa: E501
             self.assertEquals(path, u'/tmp/' + expected_path)
 
     def testDisambiguateOnReleaseOnlyOnce(self):
@@ -156,12 +157,13 @@ class PathTestCase(unittest.TestCase):
         prog.metadata = md
         template = u'%A/%d - %y/%d/%d'
 
-        path = prog.getPath(u'/tmp', template, 'mbdiscid', 0, disambiguate=True)
+        path = prog.getPath(u'/tmp', template, 'mbdiscid', 0, disambiguate=True)  # noqa: E501
         self.assertEquals(path,
-            u'/tmp/Guy Davis/Call Down the Thunder - 1996 (RHR CD 89)/Call Down the Thunder/Call Down the Thunder')
+                          u'/tmp/Guy Davis/Call Down the Thunder - 1996 (RHR CD 89)/Call Down the Thunder/Call Down the Thunder')  # noqa: E501
 
     def testDisambiguateOnNoReleaseTitle(self):
-        """Test that disambiguation gets added even if there's no release title in the template."""
+        """Test that disambiguation gets added even if there's no release
+        title in the template."""
         prog = program.Program(config.Config())
         md = mbngs.DiscMetadata()
         md.artist = 'Guy Davis'
@@ -177,7 +179,7 @@ class PathTestCase(unittest.TestCase):
         }
 
         for template, expected_path in templates.iteritems():
-            path = prog.getPath(u'/tmp', template, 'mbdiscid', 0, disambiguate=True)
+            path = prog.getPath(u'/tmp', template, 'mbdiscid', 0, disambiguate=True)  # noqa: E501
             self.assertEquals(path, u'/tmp/' + expected_path)
 
     def testAddDisambiguationUnitTest(self):

--- a/whipper/test/test_common_program.py
+++ b/whipper/test/test_common_program.py
@@ -159,3 +159,23 @@ class PathTestCase(unittest.TestCase):
         path = prog.getPath(u'/tmp', template, 'mbdiscid', 0, disambiguate=True)
         self.assertEquals(path,
             u'/tmp/Guy Davis/Call Down the Thunder - 1996 (RHR CD 89)/Call Down the Thunder/Call Down the Thunder')
+
+    def testDisambiguateOnNoReleaseTitle(self):
+        """Test that disambiguation gets added even if there's no release title in the template."""
+        prog = program.Program(config.Config())
+        md = mbngs.DiscMetadata()
+        md.artist = 'Guy Davis'
+        md.sortName = 'Davis, Guy'
+        md.title = 'Call Down the Thunder'
+        md.release = '1996'
+        md.catalogNumber = 'RHR CD 89'
+        prog.metadata = md
+        templates = {
+            u'%A/%y': u'Guy Davis/1996 (RHR CD 89)',
+            u'%A - %y': u'Guy Davis - 1996 (RHR CD 89)',
+            u'%y/%A': u'1996/Guy Davis (RHR CD 89)',
+        }
+
+        for template, expected_path in templates.iteritems():
+            path = prog.getPath(u'/tmp', template, 'mbdiscid', 0, disambiguate=True)
+            self.assertEquals(path, u'/tmp/' + expected_path)


### PR DESCRIPTION
Right now the disambiguation algorithm will just disambiguate on the first part of the template string, regardless of what actually is in the template. This leads to unexpected results like https://github.com/JoeLametta/whipper/issues/127.

This PR fixes https://github.com/JoeLametta/whipper/issues/127 but also otherwise make the disambiguation a bit more robust. See the details in the added tests and commit messages.