### PR TITLE
Fix division by zero

### DIFF
--- a/whipper/program/cdparanoia.py
+++ b/whipper/program/cdparanoia.py
@@ -196,11 +196,13 @@ class ProgressParser:
 
         # don't go over a 100%; we know cdparanoia reads each frame at least
         # twice
-        return min(frames * 2.0 / reads, 1.0)
+        try:
+            return min(frames * 2.0 / reads, 1.0)
+        except ZeroDivisionError:
+            return 0
 
 
 # FIXME: handle errors
-
 
 class ReadTrackTask(task.Task):
     """


### PR DESCRIPTION
reads can be zero sometimes an will then cause a ZeroDivisionError in the changed line.
This can happen after calling:
`$ whipper offset find`