### PR TITLE
Stop allowing flake8 to fail in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ env:
     - FLAKE8=false
     - FLAKE8=true
 
-matrix:
-    allow_failures:
-        - env: FLAKE8=true
-
 install:
     # Dependencies
     - sudo apt-get -qq update


### PR DESCRIPTION
Commit 9345357b3febf474c1bd75ddae8b0d7ff269d9d2 fixes all current flake8 errors, so unsetting this `allow_failures` makes sure that any PEP8 or similar syntax mistakes get caught immediately.