### PR TITLE
Misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ To make it easier for developers, you can run whipper straight from the
 source checkout:
 
 ```bash
-python2 setup.py develop
+python2 setup.py develop --user
 whipper -h
 ```
 

--- a/whipper/command/basecommand.py
+++ b/whipper/command/basecommand.py
@@ -93,8 +93,8 @@ class BaseCommand():
                 self.parser.print_help()
                 sys.exit(0)
             if not self.options.remainder[0] in self.subcommands:
-                sys.stderr.write("incorrect subcommand: %s" %
-                                 self.options.remainder[0])
+                logger.critical("incorrect subcommand: %s",
+                                self.options.remainder[0])
                 sys.exit(1)
             self.cmd = self.subcommands[self.options.remainder[0]](
                 self.options.remainder[1:],

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -296,13 +296,11 @@ Log files will log the path to tracks relative to this directory.
         self.parser.add_argument('--track-template',
                                  action="store", dest="track_template",
                                  default=DEFAULT_TRACK_TEMPLATE,
-                                 help="template for track file naming "
-                                 "(default default)")
+                                 help="template for track file naming")
         self.parser.add_argument('--disc-template',
                                  action="store", dest="disc_template",
                                  default=DEFAULT_DISC_TEMPLATE,
-                                 help="template for disc file naming "
-                                 "(default default)")
+                                 help="template for disc file naming")
         self.parser.add_argument('-U', '--unknown',
                                  action="store_true", dest="unknown",
                                  help="whether to continue ripping if "


### PR DESCRIPTION
First commit fixes the output of `whipper cd rip --help` (note: the CD-DA check is annoying).

The second one was motivated by the missing line break when I got the error.

Third one doesn't need much comment.