### PR TITLE
Switch to libcdio-cdparanoia (from cdparanoia)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
     # Dependencies
     - sudo apt-get -qq update
     - sudo pip install --upgrade -qq pip
-    - sudo apt-get -qq install cdparanoia cdrdao flac libcdio-dev libiso9660-dev libsndfile1-dev python-cddb python-gobject python-musicbrainzngs python-mutagen python-setuptools sox swig
+    - sudo apt-get -qq install cdparanoia cdrdao flac libcdio-dev libiso9660-dev libsndfile1-dev python-cddb python-gobject python-musicbrainzngs python-mutagen python-setuptools sox swig libcdio-utils
     - sudo pip install pycdio requests
 
     # Testing dependencies

--- a/whipper/program/cdparanoia.py
+++ b/whipper/program/cdparanoia.py
@@ -575,7 +575,7 @@ class ReadVerifyTrackTask(task.MultiSeparateTask):
 
 
 _VERSION_RE = re.compile(
-    "^cdparanoia (?P<version>.+) release (?P<release>.+) \(.*\)")
+    "^cdparanoia (?P<version>.+) release (?P<release>.+)")
 
 
 def getCdParanoiaVersion():

--- a/whipper/program/cdparanoia.py
+++ b/whipper/program/cdparanoia.py
@@ -295,10 +295,10 @@ class ReadTrackTask(task.Task):
 
         bufsize = 1024
         if self._overread:
-            argv = ["cdparanoia", "--stderr-progress",
+            argv = ["cd-paranoia", "--stderr-progress",
                     "--sample-offset=%d" % self._offset, "--force-overread", ]
         else:
-            argv = ["cdparanoia", "--stderr-progress",
+            argv = ["cd-paranoia", "--stderr-progress",
                     "--sample-offset=%d" % self._offset, ]
         if self._device:
             argv.extend(["--force-cdrom-device", self._device, ])
@@ -317,7 +317,7 @@ class ReadTrackTask(task.Task):
         except OSError as e:
             import errno
             if e.errno == errno.ENOENT:
-                raise common.MissingDependencyException('cdparanoia')
+                raise common.MissingDependencyException('cd-paranoia')
 
             raise
 
@@ -579,8 +579,8 @@ _VERSION_RE = re.compile(
 
 
 def getCdParanoiaVersion():
-    getter = common.VersionGetter('cdparanoia',
-                                  ["cdparanoia", "-V"],
+    getter = common.VersionGetter('cd-paranoia',
+                                  ["cd-paranoia", "-V"],
                                   _VERSION_RE,
                                   "%(version)s %(release)s")
 
@@ -605,12 +605,12 @@ class AnalyzeTask(ctask.PopenTask):
     def __init__(self, device=None):
         # cdparanoia -A *always* writes cdparanoia.log
         self.cwd = tempfile.mkdtemp(suffix='.whipper.cache')
-        self.command = ['cdparanoia', '-A']
+        self.command = ['cd-paranoia', '-A']
         if device:
             self.command += ['-d', device]
 
     def commandMissing(self):
-        raise common.MissingDependencyException('cdparanoia')
+        raise common.MissingDependencyException('cd-paranoia')
 
     def readbyteserr(self, bytes):
         self._output.append(bytes)

--- a/whipper/test/test_program_cdparanoia.py
+++ b/whipper/test/test_program_cdparanoia.py
@@ -68,9 +68,6 @@ class VersionTestCase(common.TestCase):
     def testGetVersion(self):
         v = cdparanoia.getCdParanoiaVersion()
         self.failUnless(v)
-        # of the form III 10.2
-        # make sure it ends with a digit
-        self.failUnless(int(v[-1]), v)
 
 
 class AnalyzeFileTask(cdparanoia.AnalyzeTask):


### PR DESCRIPTION
Next commits will add a choice to fall back to the old one, or pick a
different name. But let's get this ready for testing now.

Fixes issue #87. In the coming days I will add support to choose alternative implementations.