### PR TITLE
Run whipper without installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,7 @@ To make it easier for developers, you can run whipper straight from the
 source checkout:
 
 ```bash
-python2 setup.py develop --user
-whipper -h
+python2 -m whipper -h
 ```
 
 ## Logger plugins

--- a/whipper/__main__.py
+++ b/whipper/__main__.py
@@ -1,0 +1,10 @@
+# -*- Mode: Python -*-
+# vi:si:et:sw=4:sts=4:ts=4
+
+import sys
+
+from whipper.command.main import main
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/whipper/__main__.py
+++ b/whipper/__main__.py
@@ -1,10 +1,14 @@
 # -*- Mode: Python -*-
 # vi:si:et:sw=4:sts=4:ts=4
 
+import os
 import sys
 
 from whipper.command.main import main
 
 
 if __name__ == '__main__':
+    # Make accuraterip_checksum be found automatically if it was built
+    local_arb = os.path.join(os.path.dirname(__file__), '..', 'src')
+    os.environ['PATH'] = ':'.join([os.getenv('PATH'), local_arb])
     sys.exit(main())


### PR DESCRIPTION
This commit makes it possible to run whipper directly with
`python -m whipper` from wither within the source directory
or with `PYTHONPATH` set to the source directory.

I'm not sure if that's generally useful or people other than my like running programs like that.