### PR TITLE
Test HTOA peak value against 0 (integer comparison)

### DIFF
--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -37,7 +37,7 @@ gobject.threads_init()
 logger = logging.getLogger(__name__)
 
 
-SILENT = 1e-10
+SILENT = 0
 MAX_TRIES = 5
 
 DEFAULT_TRACK_TEMPLATE = u'%r/%A - %d/%t. %a - %n'
@@ -433,7 +433,7 @@ Log files will log the path to tracks relative to this directory.
                     )
 
                 sys.stdout.write(
-                    'Peak level: {:.2%} \n'.format(trackResult.peak))
+                    'Peak level: {}\n'.format(trackResult.peak))
 
                 sys.stdout.write(
                     'Rip quality: {:.2%}\n'.format(trackResult.quality))
@@ -442,9 +442,9 @@ Log files will log the path to tracks relative to this directory.
             if number == 0:
                 # HTOA goes on index 0 of track 1
                 # ignore silence in PREGAP
-                if trackResult.peak <= SILENT:
+                if trackResult.peak == SILENT:
                     logger.debug(
-                        'HTOA peak %r is below SILENT '
+                        'HTOA peak %r is equal to the SILENT '
                         'threshold, disregarding', trackResult.peak)
                     self.itable.setFile(1, 0, None,
                                         self.ittoc.getTrackStart(1), number)

--- a/whipper/program/sox.py
+++ b/whipper/program/sox.py
@@ -12,17 +12,20 @@ def peak_level(track_path):
 
     :param track_path: full path to audio track.
     :type track_path: str
-    :returns: track peak level from sox ('maximum amplitude') or None on error.
-    :rtype: float or None
+    :returns: track peak absolute value from sox or None on error.
+    :rtype: int or None
     """
     if not os.path.exists(track_path):
         logger.warning("SoX peak detection failed: file not found")
         return None
-    sox = Popen([SOX, track_path, "-n", "stat"], stderr=PIPE)
+    sox = Popen([SOX, track_path, "-n", "stats", "-b", "16"], stderr=PIPE)
     out, err = sox.communicate()
     if sox.returncode:
         logger.warning("SoX peak detection failed: " + str(sox.returncode))
         return None
-    # relevant captured line looks like:
-    # Maximum amplitude: 0.123456
-    return float(err.splitlines()[3].split()[2])
+    # relevant captured lines looks like this:
+    # Min level     -26215
+    # Max level      26215
+    min_level = int(err.splitlines()[2].split()[2])
+    max_level = int(err.splitlines()[3].split()[2])
+    return max(abs(min_level), abs(max_level))

--- a/whipper/result/logger.py
+++ b/whipper/result/logger.py
@@ -193,7 +193,7 @@ class WhipperLogger(result.Logger):
             lines.append("    Pre-gap length: %s" % common.framesToMSF(pregap))
 
         # Peak level
-        peak = trackResult.peak
+        peak = trackResult.peak / 32768.0
         lines.append("    Peak level: %.6f" % peak)
 
         # Pre-emphasis status

--- a/whipper/result/result.py
+++ b/whipper/result/result.py
@@ -36,7 +36,7 @@ class TrackResult:
     filename = None
     pregap = 0  # in frames
     pre_emphasis = None
-    peak = 0.0
+    peak = 0
     quality = 0.0
     testspeed = 0.0
     copyspeed = 0.0

--- a/whipper/test/test_program_sox.py
+++ b/whipper/test/test_program_sox.py
@@ -11,4 +11,4 @@ class PeakLevelTestCase(common.TestCase):
         self.path = os.path.join(os.path.dirname(__file__), 'track.flac')
 
     def testParse(self):
-        self.assertEquals(0.800018, sox.peak_level(self.path))
+        self.assertEquals(26215, sox.peak_level(self.path))


### PR DESCRIPTION
Now whipper uses the absolute value of SoX's peak level as internal peak value.

Fixes #143.