### PR TITLE
remove -T/--toc-pickle

### DIFF
--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -71,11 +71,6 @@ class _CD(BaseCommand):
 
     @staticmethod
     def add_arguments(parser):
-        # FIXME: have a cache of these pickles somewhere
-        parser.add_argument('-T', '--toc-pickle',
-                            action="store", dest="toc_pickle",
-                            help="pickle to use for reading and "
-                            "writing the TOC")
         parser.add_argument('-R', '--release-id',
                             action="store", dest="release_id",
                             help="MusicBrainz release id to match to "
@@ -103,9 +98,7 @@ class _CD(BaseCommand):
         utils.unmount_device(self.device)
 
         # first, read the normal TOC, which is fast
-        self.ittoc = self.program.getFastToc(self.runner,
-                                             self.options.toc_pickle,
-                                             self.device)
+        self.ittoc = self.program.getFastToc(self.runner, self.device)
 
         # already show us some info based on this
         self.program.getRipResult(self.ittoc.getCDDBDiscId())

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -95,24 +95,15 @@ class Program:
             logger.info('Changing to working directory %s' % workingDirectory)
             os.chdir(workingDirectory)
 
-    def getFastToc(self, runner, toc_pickle, device):
+    def getFastToc(self, runner, device):
         """Retrieve the normal TOC table from a toc pickle or the drive.
 
         Also retrieves the cdrdao version
-
-        :param runner:
-        :type runner:
-        :param toc_pickle:
-        :type toc_pickle:
-        :param device:
-        :type device:
-        :returns:
-        :rtype: tuple of L{table.Table}, str
         """
         def function(r, t):
             r.run(t)
 
-        ptoc = cache.Persister(toc_pickle or None)
+        ptoc = cache.Persister()
         if not ptoc.object:
             from pkg_resources import parse_version as V
             version = cdrdao.getCDRDAOVersion()


### PR DESCRIPTION
This is an old morituri-legacy-internals option to allow loading a specific specially created internal "toc" instead of reading it from the CD. I don't see any reason to keep it around, it only serves to confuse users (see https://github.com/JoeLametta/whipper/issues/214 ).