### PR TITLE
Incremental code modernization for (future) Python 3 port

### DIFF
--- a/whipper/command/accurip.py
+++ b/whipper/command/accurip.py
@@ -74,7 +74,7 @@ retrieves and display accuraterip data from the given URL
 
             # now sort track results in checksum by highest confidence
             sortedChecksums = []
-            for checksum, entries in checksums.items():
+            for checksum, entries in list(checksums.items()):
                 highest = max(d['confidence'] for d in entries)
                 sortedChecksums.append((highest, checksum))
 

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -222,7 +222,7 @@ Log files will log the path to tracks relative to this directory.
     # Requires opts.device
 
     def add_arguments(self):
-        loggers = result.getLoggers().keys()
+        loggers = list(result.getLoggers())
         default_offset = None
         info = drive.getDeviceInfo(self.opts.device)
         if info:

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -169,7 +169,7 @@ class _CD(BaseCommand):
             try:
                 self.program.result.cdparanoiaDefeatsCache = \
                     self.config.getDefeatsCache(*info)
-            except KeyError, e:
+            except KeyError as e:
                 logger.debug('Got key error: %r' % (e, ))
         self.program.result.artist = self.program.metadata \
             and self.program.metadata.artist \
@@ -409,7 +409,7 @@ Log files will log the path to tracks relative to this directory.
                                                   len(self.itable.tracks),
                                                   extra))
                         break
-                    except Exception, e:
+                    except Exception as e:
                         logger.debug('Got exception %r on try %d',
                                      e, tries)
 

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -333,7 +333,7 @@ Log files will log the path to tracks relative to this directory.
                 sys.stdout.write("output directory %s already exists\n" %
                                  dirname.encode('utf-8'))
         else:
-            print(("creating output directory %s" % dirname.encode('utf-8')))
+            print("creating output directory %s" % dirname.encode('utf-8'))
             os.makedirs(dirname)
 
         # FIXME: turn this into a method
@@ -460,14 +460,14 @@ Log files will log the path to tracks relative to this directory.
         htoa = self.program.getHTOA()
         if htoa:
             start, stop = htoa
-            print(('found Hidden Track One Audio from frame %d to %d' % (
-                  start, stop)))
+            print('found Hidden Track One Audio from frame %d to %d' % (
+                  start, stop))
             _ripIfNotRipped(0)
 
         for i, track in enumerate(self.itable.tracks):
             # FIXME: rip data tracks differently
             if not track.audio:
-                print(('skipping data track %d, not implemented' % (i + 1)))
+                print('skipping data track %d, not implemented' % (i + 1))
                 # FIXME: make it work for now
                 track.indexes[1].relative = 0
                 continue

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -357,7 +357,7 @@ Log files will log the path to tracks relative to this directory.
             logger.debug('ripIfNotRipped: path %r' % path)
             trackResult.number = number
 
-            assert type(path) is unicode, "%r is not unicode" % path
+            assert isinstance(path, unicode), "%r is not unicode" % path
             trackResult.filename = path
             if number > 0:
                 trackResult.pregap = self.itable.tracks[number - 1].getPregap()

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -333,7 +333,7 @@ Log files will log the path to tracks relative to this directory.
                 sys.stdout.write("output directory %s already exists\n" %
                                  dirname.encode('utf-8'))
         else:
-            print("creating output directory %s" % dirname.encode('utf-8'))
+            print(("creating output directory %s" % dirname.encode('utf-8')))
             os.makedirs(dirname)
 
         # FIXME: turn this into a method
@@ -460,14 +460,14 @@ Log files will log the path to tracks relative to this directory.
         htoa = self.program.getHTOA()
         if htoa:
             start, stop = htoa
-            print('found Hidden Track One Audio from frame %d to %d' % (
-                  start, stop))
+            print(('found Hidden Track One Audio from frame %d to %d' % (
+                  start, stop)))
             _ripIfNotRipped(0)
 
         for i, track in enumerate(self.itable.tracks):
             # FIXME: rip data tracks differently
             if not track.audio:
-                print('skipping data track %d, not implemented' % (i + 1))
+                print(('skipping data track %d, not implemented' % (i + 1)))
                 # FIXME: make it work for now
                 track.indexes[1].relative = 0
                 continue

--- a/whipper/command/image.py
+++ b/whipper/command/image.py
@@ -79,7 +79,7 @@ Retags the image from the given .cue files with tags obtained from MusicBrainz.
                                                 prompt=self.options.prompt)
 
             if not prog.metadata:
-                print 'Not in MusicBrainz database, skipping'
+                print('Not in MusicBrainz database, skipping')
                 continue
 
             prog.metadata.discid = mbdiscid
@@ -98,10 +98,10 @@ Retags the image from the given .cue files with tags obtained from MusicBrainz.
                 runner.run(t)
                 path = os.path.basename(path)
                 if t.changed:
-                    print 'Retagged %s' % path
+                    print('Retagged %s' % path)
                 else:
-                    print '%s already tagged correctly' % path
-            print
+                    print('%s already tagged correctly' % path)
+            print()
 
 
 class Verify(BaseCommand):

--- a/whipper/command/main.py
+++ b/whipper/command/main.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 def main():
     try:
         server = config.Config().get_musicbrainz_server()
-    except KeyError, e:
+    except KeyError as e:
         sys.stderr.write('whipper: %s\n' % e.message)
         sys.exit()
 
@@ -34,20 +34,20 @@ def main():
     try:
         cmd = Whipper(sys.argv[1:], os.path.basename(sys.argv[0]), None)
         ret = cmd.do()
-    except SystemError, e:
+    except SystemError as e:
         sys.stderr.write('whipper: error: %s\n' % e)
         if (type(e) is common.EjectError and
                 cmd.options.eject in ('failure', 'always')):
             eject_device(e.device)
         return 255
-    except RuntimeError, e:
+    except RuntimeError as e:
         print(e)
         return 1
     except KeyboardInterrupt:
         return 2
-    except ImportError, e:
+    except ImportError as e:
         raise
-    except task.TaskException, e:
+    except task.TaskException as e:
         if isinstance(e.exception, ImportError):
             raise ImportError(e.exception)
         elif isinstance(e.exception, common.MissingDependencyException):

--- a/whipper/command/main.py
+++ b/whipper/command/main.py
@@ -105,5 +105,5 @@ You can get help on subcommands by using the -h option to the subcommand.
             self.parser.print_help()
             sys.exit(0)
         if self.options.version:
-            print "whipper %s" % whipper.__version__
+            print("whipper %s" % whipper.__version__)
             sys.exit(0)

--- a/whipper/command/main.py
+++ b/whipper/command/main.py
@@ -30,7 +30,7 @@ def main():
     distributions, _ = pkg_resources.working_set.find_plugins(
         pkg_resources.Environment([directory.data_path('plugins')])
     )
-    map(pkg_resources.working_set.add, distributions)
+    list(map(pkg_resources.working_set.add, distributions))
     try:
         cmd = Whipper(sys.argv[1:], os.path.basename(sys.argv[0]), None)
         ret = cmd.do()

--- a/whipper/command/main.py
+++ b/whipper/command/main.py
@@ -22,7 +22,7 @@ def main():
     try:
         server = config.Config().get_musicbrainz_server()
     except KeyError as e:
-        sys.stderr.write('whipper: %s\n' % e.message)
+        sys.stderr.write('whipper: %s\n' % str(e))
         sys.exit()
 
     musicbrainzngs.set_hostname(server)

--- a/whipper/command/main.py
+++ b/whipper/command/main.py
@@ -36,7 +36,7 @@ def main():
         ret = cmd.do()
     except SystemError as e:
         sys.stderr.write('whipper: error: %s\n' % e)
-        if (type(e) is common.EjectError and
+        if (isinstance(e, common.EjectError) and
                 cmd.options.eject in ('failure', 'always')):
             eject_device(e.device)
         return 255

--- a/whipper/command/mblookup.py
+++ b/whipper/command/mblookup.py
@@ -19,26 +19,26 @@ Example disc id: KnpGsLhvH.lPrNc1PBL21lb9Bg4-"""
         try:
             discId = unicode(self.options.mbdiscid)
         except IndexError:
-            print 'Please specify a MusicBrainz disc id.'
+            print('Please specify a MusicBrainz disc id.')
             return 3
 
         metadatas = musicbrainz(discId)
 
-        print '%d releases' % len(metadatas)
+        print('%d releases' % len(metadatas))
         for i, md in enumerate(metadatas):
-            print '- Release %d:' % (i + 1, )
-            print '    Artist: %s' % md.artist.encode('utf-8')
-            print '    Title:  %s' % md.title.encode('utf-8')
-            print '    Type:   %s' % md.releaseType.encode('utf-8')  # noqa: E501
-            print '    URL:    %s' % md.url
-            print '    Tracks: %d' % len(md.tracks)
+            print('- Release %d:' % (i + 1, ))
+            print('    Artist: %s' % md.artist.encode('utf-8'))
+            print('    Title:  %s' % md.title.encode('utf-8'))
+            print('    Type:   %s' % md.releaseType.encode('utf-8'))  # noqa: E501
+            print('    URL:    %s' % md.url)
+            print('    Tracks: %d' % len(md.tracks))
             if md.catalogNumber:
-                print '    Cat no: %s' % md.catalogNumber
+                print('    Cat no: %s' % md.catalogNumber)
             if md.barcode:
-                print '   Barcode: %s' % md.barcode
+                print('   Barcode: %s' % md.barcode)
 
                 for j, track in enumerate(md.tracks):
-                    print '      Track %2d: %s - %s' % (
+                    print('      Track %2d: %s - %s' % (
                         j + 1, track.artist.encode('utf-8'),
                         track.title.encode('utf-8')
-                    )
+                    ))

--- a/whipper/command/offset.py
+++ b/whipper/command/offset.py
@@ -70,7 +70,7 @@ CD in the AccurateRip database."""
         for b in blocks:
             if ':' in b:
                 a, b = b.split(':')
-                self._offsets.extend(range(int(a), int(b) + 1))
+                self._offsets.extend(list(range(int(a), int(b) + 1)))
             else:
                 self._offsets.append(int(b))
 

--- a/whipper/command/offset.py
+++ b/whipper/command/offset.py
@@ -120,7 +120,7 @@ CD in the AccurateRip database."""
             sys.stdout.write('Trying read offset %d ...\n' % offset)
             try:
                 archecksums = self._arcs(runner, table, 1, offset)
-            except task.TaskException, e:
+            except task.TaskException as e:
 
                 # let MissingDependency fall through
                 if isinstance(e.exception,
@@ -153,7 +153,7 @@ CD in the AccurateRip database."""
                 for track in range(2, (len(table.tracks) + 1) - 1):
                     try:
                         archecksums = self._arcs(runner, table, track, offset)
-                    except task.TaskException, e:
+                    except task.TaskException as e:
                         if isinstance(e.exception, cdparanoia.FileSizeError):
                             sys.stdout.write(
                                 'WARNING: cannot rip with offset %d...\n' %

--- a/whipper/common/accurip.py
+++ b/whipper/common/accurip.py
@@ -271,9 +271,9 @@ def print_report(result):
             logger.error(
                 'no track AR CRC on non-HTOA track %d' % track.number
             )
-            print('track %2d: unknown          (error)' % track.number)
+            print(('track %2d: unknown          (error)' % track.number))
         else:
-            print('track %2d: %-16s %-23s v1 [%s], v2 [%s], DB [%s]' % (
+            print(('track %2d: %-16s %-23s v1 [%s], v2 [%s], DB [%s]' % (
                 track.number, status, conf,
                 track.AR['v1']['CRC'], track.AR['v2']['CRC'], db
-            ))
+            )))

--- a/whipper/common/accurip.py
+++ b/whipper/common/accurip.py
@@ -271,9 +271,9 @@ def print_report(result):
             logger.error(
                 'no track AR CRC on non-HTOA track %d' % track.number
             )
-            print(('track %2d: unknown          (error)' % track.number))
+            print('track %2d: unknown          (error)' % track.number)
         else:
-            print(('track %2d: %-16s %-23s v1 [%s], v2 [%s], DB [%s]' % (
+            print('track %2d: %-16s %-23s v1 [%s], v2 [%s], DB [%s]' % (
                 track.number, status, conf,
                 track.AR['v1']['CRC'], track.AR['v2']['CRC'], db
-            )))
+            ))

--- a/whipper/common/accurip.py
+++ b/whipper/common/accurip.py
@@ -231,7 +231,7 @@ def verify_result(result, responses, checksums):
     # exclude HTOA from AccurateRip verification
     # NOTE: if pre-gap hidden audio support is expanded to include
     # tracks other than HTOA, this is invalid.
-    tracks = filter(lambda t: t.number != 0, result.tracks)
+    tracks = [t for t in result.tracks if t.number != 0]
     if not tracks:
         return False
     _assign_checksums_and_confidences(tracks, checksums, responses)
@@ -251,10 +251,10 @@ def print_report(result):
             conf = '(max confidence    %3d)' % track.AR['DBMaxConfidence']
             if track.AR['v1']['DBCRC'] or track.AR['v2']['DBCRC']:
                 status = 'rip accurate'
-                db = ', '.join(filter(None, (
+                db = ', '.join([_f for _f in (
                     track.AR['v1']['DBCRC'],
                     track.AR['v2']['DBCRC']
-                )))
+                ) if _f])
             max_conf = max(
                 [track.AR[v]['DBConfidence'] for v in ('v1', 'v2')]
             )

--- a/whipper/common/accurip.py
+++ b/whipper/common/accurip.py
@@ -156,7 +156,7 @@ def _save_entry(raw_entry, path):
     # XXX: os.makedirs(exist_ok=True) in py3
     try:
         makedirs(dirname(path))
-    except OSError, e:
+    except OSError as e:
         if e.errno != EEXIST:
             logger.error('could not save entry to %s: %r' % (path, str(e)))
             return

--- a/whipper/common/cache.py
+++ b/whipper/common/cache.py
@@ -127,7 +127,7 @@ class PersistedCache:
         self.path = path
         try:
             os.makedirs(self.path)
-        except OSError, e:
+        except OSError as e:
             if e.errno != 17:  # FIXME
                 raise
 

--- a/whipper/common/common.py
+++ b/whipper/common/common.py
@@ -197,7 +197,7 @@ def getRealPath(refPath, filePath):
 
     @type  filePath: unicode
     """
-    assert type(filePath) is unicode, "%r is not unicode" % filePath
+    assert isinstance(filePath, unicode), "%r is not unicode" % filePath
 
     if os.path.exists(filePath):
         return filePath

--- a/whipper/common/common.py
+++ b/whipper/common/common.py
@@ -298,7 +298,7 @@ class VersionGetter(object):
             vre = self._regexp.search(output)
             if vre:
                 version = self._expander % vre.groupdict()
-        except OSError, e:
+        except OSError as e:
             import errno
             if e.errno == errno.ENOENT:
                 raise MissingDependencyException(self._dep)

--- a/whipper/common/drive.py
+++ b/whipper/common/drive.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 def _listify(listOrString):
-    if type(listOrString) == str:
+    if isinstance(listOrString, str):
         return [listOrString, ]
 
     return listOrString

--- a/whipper/common/encode.py
+++ b/whipper/common/encode.py
@@ -83,7 +83,7 @@ class TaggingTask(task.Task):
     def _tag(self):
         w = FLAC(self.track_path)
 
-        for k, v in self.tags.items():
+        for k, v in list(self.tags.items()):
             w[k] = v
 
         w.save()

--- a/whipper/common/mbngs.py
+++ b/whipper/common/mbngs.py
@@ -277,7 +277,7 @@ def musicbrainz(discid, country=None, record=False):
     try:
         result = musicbrainzngs.get_releases_by_discid(
             discid, includes=["artists", "recordings", "release-groups"])
-    except musicbrainzngs.ResponseError, e:
+    except musicbrainzngs.ResponseError as e:
         if isinstance(e.cause, urllib2.HTTPError):
             if e.cause.code == 404:
                 raise NotFoundException(e)

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -570,7 +570,7 @@ class Program:
 
         checksums = accurip.calculate_checksums([
             os.path.join(os.path.dirname(self.cuePath), t.indexes[1].path)
-            for t in filter(lambda t: t.number != 0, cueImage.cue.table.tracks)
+            for t in [t for t in cueImage.cue.table.tracks if t.number != 0]
         ])
         if not (checksums and any(checksums['v1']) and any(checksums['v2'])):
             return False

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -252,7 +252,7 @@ class Program:
             if code == 200:
                 return md['title']
 
-        except IOError, e:
+        except IOError as e:
             # FIXME: for some reason errno is a str ?
             if e.errno == 'socket error':
                 self._stdout.write("Warning: network error: %r\n" % (e, ))
@@ -283,13 +283,13 @@ class Program:
                                               country=country,
                                               record=self._record)
                 break
-            except mbngs.NotFoundException, e:
+            except mbngs.NotFoundException as e:
                 logger.warning("release not found: %r" % (e, ))
                 break
-            except musicbrainzngs.NetworkError, e:
+            except musicbrainzngs.NetworkError as e:
                 logger.warning("network error: %r" % (e, ))
                 break
-            except mbngs.MusicBrainzException, e:
+            except mbngs.MusicBrainzException as e:
                 logger.warning("musicbrainz exception: %r" % (e, ))
                 time.sleep(5)
                 continue
@@ -424,7 +424,7 @@ class Program:
                     title = track.title
                     mbidTrack = track.mbid
                     mbidTrackArtist = track.mbidArtist
-                except IndexError, e:
+                except IndexError as e:
                     print('ERROR: no track %d found, %r' % (number, e))
                     raise
             else:
@@ -478,7 +478,7 @@ class Program:
 
         try:
             runner.run(t)
-        except task.TaskException, e:
+        except task.TaskException as e:
             if isinstance(e.exception, common.MissingFrames):
                 logger.warning('missing frames for %r' % trackResult.filename)
                 return False

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -71,10 +71,10 @@ class Program:
 
         d = {}
 
-        for key, default in {
+        for key, default in list({
             'fat': True,
             'special': False
-        }.items():
+        }.items()):
             value = None
             value = self._config.getboolean('main', 'path_filter_' + key)
             if value is None:
@@ -375,7 +375,7 @@ class Program:
                                            releaseTitle, i,
                                            metadata.releaseTitle))
 
-                if (not release and len(deltas.keys()) > 1):
+                if (not release and len(list(deltas)) > 1):
                     self._stdout.write('\n')
                     self._stdout.write('Picked closest match in duration.\n')
                     self._stdout.write('Others may be wrong in MusicBrainz, '

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -425,7 +425,7 @@ class Program:
                     mbidTrack = track.mbid
                     mbidTrackArtist = track.mbidArtist
                 except IndexError, e:
-                    print 'ERROR: no track %d found, %r' % (number, e)
+                    print('ERROR: no track %d found, %r' % (number, e))
                     raise
             else:
                 # htoa defaults to disc's artist

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -329,7 +329,7 @@ class Program:
 
             if not release and len(metadatas) > 1:
                 # Select the release that most closely matches the duration.
-                lowest = min(deltas.keys())
+                lowest = min(list(deltas))
 
                 if prompt:
                     guess = (deltas[lowest])[0].mbid

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -115,7 +115,7 @@ class Program:
         tdict = {}
 
         # Ignore old cache, since we do not know what offset it used.
-        if type(ptable.object) is dict:
+        if isinstance(ptable.object, dict):
             tdict = ptable.object
 
             if offset in tdict:
@@ -193,8 +193,8 @@ class Program:
           - %x: audio extension, lowercase
           - %X: audio extension, uppercase
         """
-        assert type(outdir) is unicode, "%r is not unicode" % outdir
-        assert type(template) is unicode, "%r is not unicode" % template
+        assert isinstance(outdir, unicode), "%r is not unicode" % outdir
+        assert isinstance(template, unicode), "%r is not unicode" % template
         v = {}
         v['A'] = 'Unknown Artist'
         v['d'] = mbdiscid  # fallback for title

--- a/whipper/common/task.py
+++ b/whipper/common/task.py
@@ -44,7 +44,7 @@ class PopenTask(task.Task):
                                          stdout=subprocess.PIPE,
                                          stderr=subprocess.PIPE,
                                          close_fds=True, cwd=self.cwd)
-        except OSError, e:
+        except OSError as e:
             import errno
             if e.errno == errno.ENOENT:
                 self.commandMissing()
@@ -88,7 +88,7 @@ class PopenTask(task.Task):
                 return
 
             self._done()
-        except Exception, e:
+        except Exception as e:
             logger.debug('exception during _read(): %r', str(e))
             self.setException(e)
             self.stop()

--- a/whipper/extern/asyncsub.py
+++ b/whipper/extern/asyncsub.py
@@ -167,10 +167,10 @@ if __name__ == '__main__':
         shell, commands, tail = ('sh', ('ls', 'echo HELLO WORLD'), '\n')
 
     a = Popen(shell, stdin=PIPE, stdout=PIPE)
-    print recv_some(a),
+    print(recv_some(a))
     for cmd in commands:
         send_all(a, cmd + tail)
-        print recv_some(a),
+        print(recv_some(a))
     send_all(a, 'exit' + tail)
-    print recv_some(a, e=0)
+    print(recv_some(a, e=0))
     a.wait()

--- a/whipper/extern/asyncsub.py
+++ b/whipper/extern/asyncsub.py
@@ -54,7 +54,7 @@ class Popen(subprocess.Popen):
             except ValueError:
                 return self._close('stdin')
             except (subprocess.pywintypes.error, Exception), why:
-                if why[0] in (109, errno.ESHUTDOWN):
+                if why.args[0] in (109, errno.ESHUTDOWN):
                     return self._close('stdin')
                 raise
 
@@ -75,7 +75,7 @@ class Popen(subprocess.Popen):
             except ValueError:
                 return self._close(which)
             except (subprocess.pywintypes.error, Exception), why:
-                if why[0] in (109, errno.ESHUTDOWN):
+                if why.args[0] in (109, errno.ESHUTDOWN):
                     return self._close(which)
                 raise
 
@@ -95,7 +95,7 @@ class Popen(subprocess.Popen):
             try:
                 written = os.write(self.stdin.fileno(), input)
             except OSError, why:
-                if why[0] == errno.EPIPE:  # broken pipe
+                if why.args[0] == errno.EPIPE:  # broken pipe
                     return self._close('stdin')
                 raise
 

--- a/whipper/extern/task/task.py
+++ b/whipper/extern/task/task.py
@@ -237,7 +237,7 @@ class Task(LogStub):
                 method = getattr(l, methodName)
                 try:
                     method(self, *args, **kwargs)
-                except Exception, e:
+                except Exception as e:
                     self.setException(e)
 
 
@@ -349,7 +349,7 @@ class BaseMultiTask(Task, ITaskListener):
             task.start(self.runner)
             self.debug('BaseMultiTask.next(): started task %d of %d: %r',
                        self._task, len(self.tasks), task)
-        except Exception, e:
+        except Exception as e:
             self.setException(e)
             self.debug('Got exception during next: %r', self.exceptionMessage)
             self.stop()
@@ -502,7 +502,7 @@ class SyncRunner(TaskRunner, ITaskListener):
         try:
             self.debug('start task %r' % task)
             task.start(self)
-        except Exception, e:
+        except Exception as e:
             # getExceptionMessage uses global exception state that doesn't
             # hang around, so store the message
             task.setException(e)
@@ -516,7 +516,7 @@ class SyncRunner(TaskRunner, ITaskListener):
                          callable, args, kwargs)
                 callable(*args, **kwargs)
                 return False
-            except Exception, e:
+            except Exception as e:
                 self.debug('exception when calling scheduled callable %r',
                            callable)
                 task.setException(e)

--- a/whipper/extern/task/task.py
+++ b/whipper/extern/task/task.py
@@ -150,7 +150,7 @@ class Task(LogStub):
         self.debug('stopping')
         self.running = False
         if not self.runner:
-            print 'ERROR: stopping task which is already stopped'
+            print('ERROR: stopping task which is already stopped')
             import traceback
             traceback.print_stack()
         self.runner = None
@@ -214,7 +214,7 @@ class Task(LogStub):
 
     def schedule(self, delta, callable, *args, **kwargs):
         if not self.runner:
-            print "ERROR: scheduling on a task that's altready stopped"
+            print("ERROR: scheduling on a task that's altready stopped")
             import traceback
             traceback.print_stack()
             return

--- a/whipper/image/cue.py
+++ b/whipper/image/cue.py
@@ -71,7 +71,7 @@ class CueFile(object):
         """
         @type  path: unicode
         """
-        assert type(path) is unicode, "%r is not unicode" % path
+        assert isinstance(path, unicode), "%r is not unicode" % path
 
         self._path = path
         self._rems = {}
@@ -196,7 +196,7 @@ class File:
         """
         @type  path: unicode
         """
-        assert type(path) is unicode, "%r is not unicode" % path
+        assert isinstance(path, unicode), "%r is not unicode" % path
 
         self.path = path
         self.format = format

--- a/whipper/image/cue.py
+++ b/whipper/image/cue.py
@@ -130,7 +130,7 @@ class CueFile(object):
             if m:
                 if not currentTrack:
                     self.message(number, 'INDEX without preceding TRACK')
-                    print 'ouch'
+                    print('ouch')
                     continue
 
                 indexNumber = int(m.expand('\\1'))

--- a/whipper/image/image.py
+++ b/whipper/image/image.py
@@ -46,7 +46,7 @@ class Image(object):
         @type  path: unicode
         @param path: .cue path
         """
-        assert type(path) is unicode, "%r is not unicode" % path
+        assert isinstance(path, unicode), "%r is not unicode" % path
 
         self._path = path
         self.cue = cue.CueFile(path)
@@ -62,7 +62,7 @@ class Image(object):
 
         @param path: .cue path
         """
-        assert type(path) is unicode, "%r is not unicode" % path
+        assert isinstance(path, unicode), "%r is not unicode" % path
 
         return self.cue.getRealPath(path)
 
@@ -129,7 +129,7 @@ class ImageVerifyTask(task.MultiSeparateTask):
             htoa = cue.table.tracks[0].indexes[0]
             track = cue.table.tracks[0]
             path = image.getRealPath(htoa.path)
-            assert type(path) is unicode, "%r is not unicode" % path
+            assert isinstance(path, unicode), "%r is not unicode" % path
             logger.debug('schedule scan of audio length of %r', path)
             taskk = AudioLengthTask(path)
             self.addTask(taskk)
@@ -144,7 +144,7 @@ class ImageVerifyTask(task.MultiSeparateTask):
 
             if length == -1:
                 path = image.getRealPath(index.path)
-                assert type(path) is unicode, "%r is not unicode" % path
+                assert isinstance(path, unicode), "%r is not unicode" % path
                 logger.debug('schedule scan of audio length of %r', path)
                 taskk = AudioLengthTask(path)
                 self.addTask(taskk)
@@ -190,7 +190,7 @@ class ImageEncodeTask(task.MultiSeparateTask):
         def add(index):
 
             path = image.getRealPath(index.path)
-            assert type(path) is unicode, "%r is not unicode" % path
+            assert isinstance(path, unicode), "%r is not unicode" % path
             logger.debug('schedule encode of %r', path)
             root, ext = os.path.splitext(os.path.basename(path))
             outpath = os.path.join(outdir, root + '.' + 'flac')

--- a/whipper/image/table.py
+++ b/whipper/image/table.py
@@ -107,12 +107,12 @@ class Track:
         Typically this is INDEX 01; but it could be INDEX 00 if there's
         a pre-gap.
         """
-        indexes = self.indexes.keys()
+        indexes = list(self.indexes.keys())
         indexes.sort()
         return self.indexes[indexes[0]]
 
     def getLastIndex(self):
-        indexes = self.indexes.keys()
+        indexes = list(self.indexes.keys())
         indexes.sort()
         return self.indexes[indexes[-1]]
 
@@ -543,7 +543,7 @@ class Table(object):
             if not track.audio:
                 continue
 
-            indexes = track.indexes.keys()
+            indexes = list(track.indexes.keys())
             indexes.sort()
 
             wroteTrack = False
@@ -724,7 +724,7 @@ class Table(object):
             t = copy.deepcopy(track)
             t.number = track.number + trackCount
             t.session = session
-            for i in t.indexes.values():
+            for i in list(t.indexes.values()):
                 if i.absolute is not None:
                     i.absolute += self.leadout + gap
                     logger.debug('Fixing track %02d, index %02d, '
@@ -768,7 +768,7 @@ class Table(object):
         @rtype: tuple of (int, int)
         """
         t = self.tracks[track - 1]
-        indexes = t.indexes.keys()
+        indexes = list(t.indexes)
         position = indexes.index(index)
 
         if position + 1 < len(indexes):
@@ -780,7 +780,7 @@ class Table(object):
                 track - 1, index))
 
         t = self.tracks[track - 1]
-        indexes = t.indexes.keys()
+        indexes = list(t.indexes)
 
         return track, indexes[0]
 
@@ -797,7 +797,7 @@ class Table(object):
             return False
 
         for t in self.tracks:
-            if 1 not in t.indexes.keys():
+            if 1 not in list(t.indexes):
                 logger.debug('no index 1, no TOC')
                 return False
             if t.indexes[1].absolute is None:
@@ -850,7 +850,7 @@ class Table(object):
             return False
 
         for t in self.tracks:
-            for i in t.indexes.values():
+            for i in list(t.indexes.values()):
                 if i.relative is None:
                     logger.debug('Track %02d, Index %02d does not '
                                  'have relative', t.number, i.number)

--- a/whipper/image/table.py
+++ b/whipper/image/table.py
@@ -92,7 +92,7 @@ class Track:
         @type path:  unicode or None
         """
         if path is not None:
-            assert type(path) is unicode, "%r is not unicode" % path
+            assert isinstance(path, unicode), "%r is not unicode" % path
 
         i = Index(number, absolute, path, relative, counter)
         self.indexes[number] = i
@@ -107,13 +107,11 @@ class Track:
         Typically this is INDEX 01; but it could be INDEX 00 if there's
         a pre-gap.
         """
-        indexes = list(self.indexes.keys())
-        indexes.sort()
+        indexes = sorted(self.indexes.keys())
         return self.indexes[indexes[0]]
 
     def getLastIndex(self):
-        indexes = list(self.indexes.keys())
-        indexes.sort()
+        indexes = sorted(self.indexes.keys())
         return self.indexes[indexes[-1]]
 
     def getPregap(self):
@@ -145,7 +143,7 @@ class Index:
                  counter=None):
 
         if path is not None:
-            assert type(path) is unicode, "%r is not unicode" % path
+            assert isinstance(path, unicode), "%r is not unicode" % path
 
         self.number = number
         self.absolute = absolute
@@ -543,8 +541,7 @@ class Table(object):
             if not track.audio:
                 continue
 
-            indexes = list(track.indexes.keys())
-            indexes.sort()
+            indexes = sorted(track.indexes.keys())
 
             wroteTrack = False
 

--- a/whipper/image/toc.py
+++ b/whipper/image/toc.py
@@ -140,7 +140,7 @@ class TocFile(object):
         """
         @type  path: unicode
         """
-        assert type(path) is unicode, "%r is not unicode" % path
+        assert isinstance(path, unicode), "%r is not unicode" % path
         self._path = path
         self._messages = []
         self.table = table.Table()
@@ -430,7 +430,7 @@ class File:
         @param start:  starting point for the track in this file, in frames
         @param length: length for the track in this file, in frames
         """
-        assert type(path) is unicode, "%r is not unicode" % path
+        assert isinstance(path, unicode), "%r is not unicode" % path
 
         self.path = path
         self.start = start

--- a/whipper/image/toc.py
+++ b/whipper/image/toc.py
@@ -338,7 +338,7 @@ class TocFile(object):
             if m:
                 if not currentTrack:
                     self.message(number, 'START without preceding TRACK')
-                    print 'ouch'
+                    print('ouch')
                     continue
 
                 length = common.msfToFrames(m.group('length'))
@@ -362,7 +362,7 @@ class TocFile(object):
             if m:
                 if not currentTrack:
                     self.message(number, 'INDEX without preceding TRACK')
-                    print 'ouch'
+                    print('ouch')
                     continue
 
                 indexNumber += 1

--- a/whipper/program/cdparanoia.py
+++ b/whipper/program/cdparanoia.py
@@ -161,7 +161,7 @@ class ProgressParser:
         # FIXME: doing this is way too slow even for a testcase, so disable
         if False:
             for frame in range(markStart, markEnd):
-                if frame not in self._reads.keys():
+                if frame not in list(self._reads.keys()):
                     self._reads[frame] = 0
                 self._reads[frame] += 1
 

--- a/whipper/program/cdparanoia.py
+++ b/whipper/program/cdparanoia.py
@@ -299,7 +299,7 @@ class ReadTrackTask(task.Task):
                                          stdout=subprocess.PIPE,
                                          stderr=subprocess.PIPE,
                                          close_fds=True)
-        except OSError, e:
+        except OSError as e:
             import errno
             if e.errno == errno.ENOENT:
                 raise common.MissingDependencyException('cd-paranoia')
@@ -478,7 +478,7 @@ class ReadVerifyTrackTask(task.MultiSeparateTask):
         try:
             tmpoutpath = path + u'.part'
             open(tmpoutpath, 'wb').close()
-        except IOError, e:
+        except IOError as e:
             if errno.ENAMETOOLONG != e.errno:
                 raise
             path = common.shrinkPath(path)
@@ -540,7 +540,7 @@ class ReadVerifyTrackTask(task.MultiSeparateTask):
                     try:
                         logger.debug('Moving to final path %r', self.path)
                         os.rename(self._tmppath, self.path)
-                    except Exception, e:
+                    except Exception as e:
                         logger.debug('Exception while moving to final '
                                      'path %r: %r', self.path, str(e))
                         self.exception = e
@@ -548,7 +548,7 @@ class ReadVerifyTrackTask(task.MultiSeparateTask):
                     os.unlink(self._tmppath)
             else:
                 logger.debug('stop: exception %r', self.exception)
-        except Exception, e:
+        except Exception as e:
             print('WARNING: unhandled exception %r' % (e, ))
 
         task.MultiSeparateTask.stop(self)

--- a/whipper/program/cdparanoia.py
+++ b/whipper/program/cdparanoia.py
@@ -384,7 +384,7 @@ class ReadTrackTask(task.Task):
 
         if not self.exception and self._popen.returncode != 0:
             if self._errors:
-                print "\n".join(self._errors)
+                print("\n".join(self._errors))
             else:
                 logger.warning('exit code %r', self._popen.returncode)
                 self.exception = ReturnCodeError(self._popen.returncode)
@@ -549,7 +549,7 @@ class ReadVerifyTrackTask(task.MultiSeparateTask):
             else:
                 logger.debug('stop: exception %r', self.exception)
         except Exception, e:
-            print 'WARNING: unhandled exception %r' % (e, )
+            print('WARNING: unhandled exception %r' % (e, ))
 
         task.MultiSeparateTask.stop(self)
 

--- a/whipper/program/cdparanoia.py
+++ b/whipper/program/cdparanoia.py
@@ -238,7 +238,7 @@ class ReadTrackTask(task.Task):
         @param what:   a string representing what's being read; e.g. Track
         @type  what:   str
         """
-        assert type(path) is unicode, "%r is not unicode" % path
+        assert isinstance(path, unicode), "%r is not unicode" % path
 
         self.path = path
         self._table = table

--- a/whipper/program/soxi.py
+++ b/whipper/program/soxi.py
@@ -23,7 +23,7 @@ class AudioLengthTask(ctask.PopenTask):
         """
         @type  path: unicode
         """
-        assert type(path) is unicode, "%r is not unicode" % path
+        assert isinstance(path, unicode), "%r is not unicode" % path
 
         self.logName = os.path.basename(path).encode('utf-8')
 

--- a/whipper/program/utils.py
+++ b/whipper/program/utils.py
@@ -31,5 +31,5 @@ def unmount_device(device):
     logger.debug('possibly unmount real path %r' % device)
     proc = open('/proc/mounts').read()
     if device in proc:
-        print 'Device %s is mounted, unmounting' % device
+        print('Device %s is mounted, unmounting' % device)
         os.system('umount %s' % device)

--- a/whipper/test/common.py
+++ b/whipper/test/common.py
@@ -30,7 +30,7 @@ def _diff(old, new, desc):
 
 def diffStrings(orig, new, desc='input'):
 
-    assert type(orig) == type(new), 'type %s and %s are different' % (
+    assert isinstance(orig, type(new)), 'type %s and %s are different' % (
         type(orig), type(new))
 
     def _tolines(s):

--- a/whipper/test/common.py
+++ b/whipper/test/common.py
@@ -49,9 +49,9 @@ class TestCase(unittest.TestCase):
     def failUnlessRaises(self, exception, f, *args, **kwargs):
         try:
             result = f(*args, **kwargs)
-        except exception, inst:
+        except exception as inst:
             return inst
-        except exception, e:
+        except exception as e:
             raise Exception('%s raised instead of %s:\n %s' %
                             (sys.exec_info()[0], exception.__name__, str(e))
                             )

--- a/whipper/test/test_common_accurip.py
+++ b/whipper/test/test_common_accurip.py
@@ -31,7 +31,7 @@ class TestAccurateRipResponse(TestCase):
         accurip._CACHE_DIR = self.cache_dir
 
         def cleanup(cachedir):
-            chmod(cachedir, 0755)
+            chmod(cachedir, 0o755)
             rmtree(cachedir)
         self.addCleanup(cleanup, self.cache_dir)
 
@@ -52,7 +52,7 @@ class TestAccurateRipResponse(TestCase):
     def test_can_return_entry_without_saving(self):
         chmod(self.cache_dir, 0)
         self.assertEqual(get_db_entry(self.path), self.entry)
-        chmod(self.cache_dir, 0755)
+        chmod(self.cache_dir, 0o755)
         self.assertFalse(exists(join(self.cache_dir, self.path)))
 
     def test_retrieves_and_saves_accuraterip_entry(self):

--- a/whipper/test/test_common_accurip.py
+++ b/whipper/test/test_common_accurip.py
@@ -43,7 +43,7 @@ class TestAccurateRipResponse(TestCase):
             join(self.cache_dir, self.other_path)
         )
         # ask cache for other entry and assert cached entry equals normal entry
-        self.assertEquals(self.entry, get_db_entry(self.other_path))
+        self.assertEqual(self.entry, get_db_entry(self.other_path))
 
     def test_raises_entrynotfound_for_no_entry(self):
         with self.assertRaises(EntryNotFound):
@@ -58,37 +58,37 @@ class TestAccurateRipResponse(TestCase):
     def test_retrieves_and_saves_accuraterip_entry(self):
         # for path, entry in zip(self.paths[0], self.entries):
         self.assertFalse(exists(join(self.cache_dir, self.path)))
-        self.assertEquals(get_db_entry(self.path), self.entry)
+        self.assertEqual(get_db_entry(self.path), self.entry)
         self.assertTrue(exists(join(self.cache_dir, self.path)))
 
     def test_AccurateRipResponse_parses_correctly(self):
         responses = get_db_entry(self.path)
-        self.assertEquals(len(responses), 2)
+        self.assertEqual(len(responses), 2)
 
-        self.assertEquals(responses[0].num_tracks, 2)
-        self.assertEquals(responses[0].discId1, '0000f21c')
-        self.assertEquals(responses[0].discId2, '00027ef8')
-        self.assertEquals(responses[0].cddbDiscId, '05021002')
-        self.assertEquals(responses[0].confidences[0], 12)
-        self.assertEquals(responses[0].confidences[1], 20)
-        self.assertEquals(responses[0].checksums[0], '284fc705')
-        self.assertEquals(responses[0].checksums[1], '9cc1f32e')
+        self.assertEqual(responses[0].num_tracks, 2)
+        self.assertEqual(responses[0].discId1, '0000f21c')
+        self.assertEqual(responses[0].discId2, '00027ef8')
+        self.assertEqual(responses[0].cddbDiscId, '05021002')
+        self.assertEqual(responses[0].confidences[0], 12)
+        self.assertEqual(responses[0].confidences[1], 20)
+        self.assertEqual(responses[0].checksums[0], '284fc705')
+        self.assertEqual(responses[0].checksums[1], '9cc1f32e')
 
-        self.assertEquals(responses[1].num_tracks, 2)
-        self.assertEquals(responses[1].discId1, '0000f21c')
-        self.assertEquals(responses[1].discId2, '00027ef8')
-        self.assertEquals(responses[1].cddbDiscId, '05021002')
-        self.assertEquals(responses[1].confidences[0], 4)
-        self.assertEquals(responses[1].confidences[1], 4)
-        self.assertEquals(responses[1].checksums[0], 'dc77f9ab')
-        self.assertEquals(responses[1].checksums[1], 'dd97d2c3')
+        self.assertEqual(responses[1].num_tracks, 2)
+        self.assertEqual(responses[1].discId1, '0000f21c')
+        self.assertEqual(responses[1].discId2, '00027ef8')
+        self.assertEqual(responses[1].cddbDiscId, '05021002')
+        self.assertEqual(responses[1].confidences[0], 4)
+        self.assertEqual(responses[1].confidences[1], 4)
+        self.assertEqual(responses[1].checksums[0], 'dc77f9ab')
+        self.assertEqual(responses[1].checksums[1], 'dd97d2c3')
 
 # XXX: test arc.py
 
 
 class TestCalculateChecksums(TestCase):
     def test_returns_none_for_bad_files(self):
-        self.assertEquals(
+        self.assertEqual(
             calculate_checksums(['/does/not/exist']),
             {'v1': [None], 'v2': [None]}
         )
@@ -116,26 +116,26 @@ class TestVerifyResult(TestCase):
             self.result.tracks.append(track)
 
     def test_empty_result_returns_false(self):
-        self.assertEquals(
+        self.assertEqual(
             verify_result(RipResult(), self.responses, self.checksums),
             False
         )
 
     def test_empty_responses_returns_false(self):
-        self.assertEquals(
+        self.assertEqual(
             verify_result(self.result, [], self.checksums),
             False
         )
 
     # XXX: would this happen?
     def test_empty_checksums_returns_false(self):
-        self.assertEquals(
+        self.assertEqual(
             verify_result(self.result, self.responses, {}),
             False
         )
 
     def test_wrong_checksums_returns_false(self):
-        self.assertEquals(
+        self.assertEqual(
             verify_result(self.result, self.responses, {
                 'v1': ['deadbeef', '89abcdef'],
                 'v2': ['76543210', '01234567']
@@ -144,21 +144,21 @@ class TestVerifyResult(TestCase):
         )
 
     def test_incomplete_checksums(self):
-        self.assertEquals(
+        self.assertEqual(
             verify_result(self.result, self.responses, {
                 'v1': ['284fc705', '9cc1f32e'],
                 'v2': [None, 'dd97d2c3'],
             }),
             True
         )
-        self.assertEquals(
+        self.assertEqual(
             verify_result(self.result, self.responses, {
                 'v1': ['284fc705', None],
                 'v2': ['dc77f9ab', 'dd97d2c3'],
             }),
             True
         )
-        self.assertEquals(
+        self.assertEqual(
             verify_result(self.result, self.responses, {
                 'v1': ['284fc705', None],
                 'v2': [None, 'dd97d2c3'],
@@ -167,13 +167,13 @@ class TestVerifyResult(TestCase):
         )
 
     def test_matches_only_v1_or_v2_responses(self):
-        self.assertEquals(
+        self.assertEqual(
             verify_result(
                 self.result, [self.responses[0]], self.checksums
             ),
             True
         )
-        self.assertEquals(
+        self.assertEqual(
             verify_result(
                 self.result, [self.responses[1]], self.checksums
             ),
@@ -184,17 +184,17 @@ class TestVerifyResult(TestCase):
         htoa = TrackResult()
         htoa.number = 0
         self.result.tracks.append(htoa)
-        self.assertEquals(
+        self.assertEqual(
             verify_result(self.result, self.responses, self.checksums),
             True
         )
 
     def test_stores_accuraterip_results_on_result(self):
-        self.assertEquals(
+        self.assertEqual(
             verify_result(self.result, self.responses, self.checksums),
             True
         )
-        self.assertEquals(self.result.tracks[0].AR, {
+        self.assertEqual(self.result.tracks[0].AR, {
             'v1': {
                 'CRC': '284fc705',
                 'DBCRC': '284fc705',
@@ -208,7 +208,7 @@ class TestVerifyResult(TestCase):
             'DBMaxConfidence': 12,
             'DBMaxConfidenceCRC': '284fc705',
         })
-        self.assertEquals(self.result.tracks[1].AR, {
+        self.assertEqual(self.result.tracks[1].AR, {
             'v1': {
                 'CRC': '9cc1f32e',
                 'DBCRC': '9cc1f32e',
@@ -254,7 +254,7 @@ class TestAccurateRipReport(TestCase):
         track.number = 1
         self.result.tracks[0] = track
         print_report(self.result)
-        self.assertEquals(
+        self.assertEqual(
             sys.stdout.getvalue(),
             'track  1: unknown          (error)\n'
         )
@@ -262,7 +262,7 @@ class TestAccurateRipReport(TestCase):
     def test_track_not_found(self):
         self.result.tracks[0].AR['DBMaxConfidence'] = None
         print_report(self.result)
-        self.assertEquals(
+        self.assertEqual(
             sys.stdout.getvalue(),
             'track  1: rip NOT accurate (not found)            '
             ' v1 [284fc705], v2 [dc77f9ab], DB [notfound]\n'
@@ -273,7 +273,7 @@ class TestAccurateRipReport(TestCase):
         self.result.tracks[0].AR['v1']['CRC'] = None
         self.result.tracks[0].AR['v2']['CRC'] = None
         print_report(self.result)
-        self.assertEquals(
+        self.assertEqual(
             sys.stdout.getvalue(),
             'track  0: unknown          (not tracked)\n'
         )
@@ -282,7 +282,7 @@ class TestAccurateRipReport(TestCase):
         self.result.tracks[0].AR['v2']['DBCRC'] = None
         self.result.tracks[0].AR['v2']['DBConfidence'] = None
         print_report(self.result)
-        self.assertEquals(
+        self.assertEqual(
             sys.stdout.getvalue(),
             'track  1: rip accurate     (max confidence     12)'
             ' v1 [284fc705], v2 [dc77f9ab], DB [284fc705]\n'
@@ -292,7 +292,7 @@ class TestAccurateRipReport(TestCase):
         self.result.tracks[0].AR['v1']['DBCRC'] = None
         self.result.tracks[0].AR['v1']['DBConfidence'] = None
         print_report(self.result)
-        self.assertEquals(
+        self.assertEqual(
             sys.stdout.getvalue(),
             'track  1: rip accurate     (confidence   4 of  12)'
             ' v1 [284fc705], v2 [dc77f9ab], DB [dc77f9ab]\n'
@@ -300,7 +300,7 @@ class TestAccurateRipReport(TestCase):
 
     def test_report_v1_and_v2_max_confidence(self):
         print_report(self.result)
-        self.assertEquals(
+        self.assertEqual(
             sys.stdout.getvalue(),
             'track  1: rip accurate     (max confidence     12)'
             ' v1 [284fc705], v2 [dc77f9ab], DB [284fc705, dc77f9ab]\n'
@@ -309,7 +309,7 @@ class TestAccurateRipReport(TestCase):
     def test_report_v1_and_v2(self):
         self.result.tracks[0].AR['DBMaxConfidence'] = 66
         print_report(self.result)
-        self.assertEquals(
+        self.assertEqual(
             sys.stdout.getvalue(),
             'track  1: rip accurate     (confidence  12 of  66)'
             ' v1 [284fc705], v2 [dc77f9ab], DB [284fc705, dc77f9ab]\n'

--- a/whipper/test/test_common_cache.py
+++ b/whipper/test/test_common_cache.py
@@ -16,8 +16,8 @@ class ResultCacheTestCase(tcommon.TestCase):
 
     def testGetResult(self):
         result = self.cache.getRipResult('fe105a11')
-        self.assertEquals(result.object.title, "The Writing's on the Wall")
+        self.assertEqual(result.object.title, "The Writing's on the Wall")
 
     def testGetIds(self):
         ids = self.cache.getIds()
-        self.assertEquals(ids, ['fe105a11'])
+        self.assertEqual(ids, ['fe105a11'])

--- a/whipper/test/test_common_common.py
+++ b/whipper/test/test_common_common.py
@@ -21,7 +21,7 @@ class ShrinkTestCase(tcommon.TestCase):
                 'Are Off Our Lands!".flac')
 
         shorter = common.shrinkPath(path)
-        self.failUnless(os.path.splitext(path)[0].startswith(
+        self.assertTrue(os.path.splitext(path)[0].startswith(
             os.path.splitext(shorter)[0]))
         self.failIfEquals(path, shorter)
 
@@ -29,13 +29,13 @@ class ShrinkTestCase(tcommon.TestCase):
 class FramesTestCase(tcommon.TestCase):
 
     def testFrames(self):
-        self.assertEquals(common.framesToHMSF(123456), '00:27:26.06')
+        self.assertEqual(common.framesToHMSF(123456), '00:27:26.06')
 
 
 class FormatTimeTestCase(tcommon.TestCase):
 
     def testFormatTime(self):
-        self.assertEquals(common.formatTime(7202), '02:00:02.000')
+        self.assertEqual(common.formatTime(7202), '02:00:02.000')
 
 
 class GetRelativePathTestCase(tcommon.TestCase):
@@ -45,7 +45,7 @@ class GetRelativePathTestCase(tcommon.TestCase):
         cue = './' + directory + '/Placebo - Black Market Music (2000)'
         track = './' + directory + '/01. Placebo - Taste in Men.flac'
 
-        self.assertEquals(common.getRelativePath(track, cue),
+        self.assertEqual(common.getRelativePath(track, cue),
                           '01. Placebo - Taste in Men.flac')
 
 
@@ -55,12 +55,12 @@ class GetRealPathTestCase(tcommon.TestCase):
         fd, path = tempfile.mkstemp(suffix=u'back\\slash.flac')
         refPath = os.path.join(os.path.dirname(path), 'fake.cue')
 
-        self.assertEquals(common.getRealPath(refPath, path),
+        self.assertEqual(common.getRealPath(refPath, path),
                           path)
 
         # same path, but with wav extension, will point to flac file
         wavPath = path[:-4] + 'wav'
-        self.assertEquals(common.getRealPath(refPath, wavPath),
+        self.assertEqual(common.getRealPath(refPath, wavPath),
                           path)
 
         os.close(fd)

--- a/whipper/test/test_common_common.py
+++ b/whipper/test/test_common_common.py
@@ -46,7 +46,7 @@ class GetRelativePathTestCase(tcommon.TestCase):
         track = './' + directory + '/01. Placebo - Taste in Men.flac'
 
         self.assertEqual(common.getRelativePath(track, cue),
-                          '01. Placebo - Taste in Men.flac')
+                         '01. Placebo - Taste in Men.flac')
 
 
 class GetRealPathTestCase(tcommon.TestCase):
@@ -55,13 +55,11 @@ class GetRealPathTestCase(tcommon.TestCase):
         fd, path = tempfile.mkstemp(suffix=u'back\\slash.flac')
         refPath = os.path.join(os.path.dirname(path), 'fake.cue')
 
-        self.assertEqual(common.getRealPath(refPath, path),
-                          path)
+        self.assertEqual(common.getRealPath(refPath, path), path)
 
         # same path, but with wav extension, will point to flac file
         wavPath = path[:-4] + 'wav'
-        self.assertEqual(common.getRealPath(refPath, wavPath),
-                          path)
+        self.assertEqual(common.getRealPath(refPath, wavPath), path)
 
         os.close(fd)
         os.unlink(path)

--- a/whipper/test/test_common_config.py
+++ b/whipper/test/test_common_config.py
@@ -27,13 +27,13 @@ class ConfigTestCase(tcommon.TestCase):
         # getting it from memory should work
         offset = self._config.getReadOffset(
             'PLEXTOR ', 'DVDR   PX-L890SA', '1.05')
-        self.assertEquals(offset, 6)
+        self.assertEqual(offset, 6)
 
         # and so should getting it after reading it again
         self._config.open()
         offset = self._config.getReadOffset(
             'PLEXTOR ', 'DVDR   PX-L890SA', '1.05')
-        self.assertEquals(offset, 6)
+        self.assertEqual(offset, 6)
 
     def testAddReadOffsetSpaced(self):
         self.assertRaises(KeyError, self._config.getReadOffset,
@@ -43,13 +43,13 @@ class ConfigTestCase(tcommon.TestCase):
         # getting it from memory should work
         offset = self._config.getReadOffset(
             'Slimtype', 'eSAU208   2     ', 'ML03')
-        self.assertEquals(offset, 6)
+        self.assertEqual(offset, 6)
 
         # and so should getting it after reading it again
         self._config.open()
         offset = self._config.getReadOffset(
             'Slimtype', 'eSAU208   2     ', 'ML03')
-        self.assertEquals(offset, 6)
+        self.assertEqual(offset, 6)
 
     def testDefeatsCache(self):
         self.assertRaises(KeyError, self._config.getDefeatsCache,
@@ -59,16 +59,16 @@ class ConfigTestCase(tcommon.TestCase):
             'PLEXTOR ', 'DVDR   PX-L890SA', '1.05', False)
         defeats = self._config.getDefeatsCache(
             'PLEXTOR ', 'DVDR   PX-L890SA', '1.05')
-        self.assertEquals(defeats, False)
+        self.assertEqual(defeats, False)
 
         self._config.setDefeatsCache(
             'PLEXTOR ', 'DVDR   PX-L890SA', '1.05', True)
         defeats = self._config.getDefeatsCache(
             'PLEXTOR ', 'DVDR   PX-L890SA', '1.05')
-        self.assertEquals(defeats, True)
+        self.assertEqual(defeats, True)
 
     def test_get_musicbrainz_server(self):
-        self.assertEquals(self._config.get_musicbrainz_server(),
+        self.assertEqual(self._config.get_musicbrainz_server(),
                           'musicbrainz.org',
                           msg='Default value is correct')
 
@@ -77,7 +77,7 @@ class ConfigTestCase(tcommon.TestCase):
         self._config._parser.set('musicbrainz', 'server',
                                  '192.168.2.141:5000')
         self._config.write()
-        self.assertEquals(self._config.get_musicbrainz_server(),
+        self.assertEqual(self._config.get_musicbrainz_server(),
                           '192.168.2.141:5000',
                           msg='Correctly returns user-set value')
 

--- a/whipper/test/test_common_config.py
+++ b/whipper/test/test_common_config.py
@@ -69,8 +69,8 @@ class ConfigTestCase(tcommon.TestCase):
 
     def test_get_musicbrainz_server(self):
         self.assertEqual(self._config.get_musicbrainz_server(),
-                          'musicbrainz.org',
-                          msg='Default value is correct')
+                         'musicbrainz.org',
+                         msg='Default value is correct')
 
         self._config._parser.add_section('musicbrainz')
 
@@ -78,8 +78,8 @@ class ConfigTestCase(tcommon.TestCase):
                                  '192.168.2.141:5000')
         self._config.write()
         self.assertEqual(self._config.get_musicbrainz_server(),
-                          '192.168.2.141:5000',
-                          msg='Correctly returns user-set value')
+                         '192.168.2.141:5000',
+                         msg='Correctly returns user-set value')
 
         self._config._parser.set('musicbrainz', 'server',
                                  '192.168.2.141:5000/hello/world')

--- a/whipper/test/test_common_directory.py
+++ b/whipper/test/test_common_directory.py
@@ -12,7 +12,7 @@ class DirectoryTestCase(common.TestCase):
 
     def testAll(self):
         path = directory.config_path()
-        self.failUnless(path.startswith(DirectoryTestCase.HOME_PARENT))
+        self.assertTrue(path.startswith(DirectoryTestCase.HOME_PARENT))
 
         path = directory.cache_path()
-        self.failUnless(path.startswith(DirectoryTestCase.HOME_PARENT))
+        self.assertTrue(path.startswith(DirectoryTestCase.HOME_PARENT))

--- a/whipper/test/test_common_drive.py
+++ b/whipper/test/test_common_drive.py
@@ -9,8 +9,8 @@ class ListifyTestCase(common.TestCase):
 
     def testString(self):
         string = '/dev/sr0'
-        self.assertEquals(drive._listify(string), [string, ])
+        self.assertEqual(drive._listify(string), [string, ])
 
     def testList(self):
         lst = ['/dev/scd0', '/dev/sr0']
-        self.assertEquals(drive._listify(lst), lst)
+        self.assertEqual(drive._listify(lst), lst)

--- a/whipper/test/test_common_mbngs.py
+++ b/whipper/test/test_common_mbngs.py
@@ -22,7 +22,7 @@ class MetadataTestCase(unittest.TestCase):
 
         metadata = mbngs._getMetadata({}, response['release'], discid)
 
-        self.failIf(metadata.release)
+        self.assertFalse(metadata.release)
 
     def test2MeterSessies10(self):
         # various artists, multiple artists per track
@@ -35,21 +35,21 @@ class MetadataTestCase(unittest.TestCase):
 
         metadata = mbngs._getMetadata({}, response['release'], discid)
 
-        self.assertEquals(metadata.artist, u'Various Artists')
-        self.assertEquals(metadata.release, u'2001-10-15')
-        self.assertEquals(metadata.mbidArtist,
+        self.assertEqual(metadata.artist, u'Various Artists')
+        self.assertEqual(metadata.release, u'2001-10-15')
+        self.assertEqual(metadata.mbidArtist,
                           u'89ad4ac3-39f7-470e-963a-56509c546377')
 
-        self.assertEquals(len(metadata.tracks), 18)
+        self.assertEqual(len(metadata.tracks), 18)
 
         track16 = metadata.tracks[15]
 
-        self.assertEquals(track16.artist, 'Tom Jones & Stereophonics')
-        self.assertEquals(track16.mbidArtist,
+        self.assertEqual(track16.artist, 'Tom Jones & Stereophonics')
+        self.assertEqual(track16.mbidArtist,
                           u'57c6f649-6cde-48a7-8114-2a200247601a'
                           ';0bfba3d3-6a04-4779-bb0a-df07df5b0558'
                           )
-        self.assertEquals(track16.sortName,
+        self.assertEqual(track16.sortName,
                           u'Jones, Tom & Stereophonics')
 
     def testBalladOfTheBrokenSeas(self):
@@ -63,24 +63,24 @@ class MetadataTestCase(unittest.TestCase):
 
         metadata = mbngs._getMetadata({}, response['release'], discid)
 
-        self.assertEquals(metadata.artist, u'Isobel Campbell & Mark Lanegan')
-        self.assertEquals(metadata.sortName,
+        self.assertEqual(metadata.artist, u'Isobel Campbell & Mark Lanegan')
+        self.assertEqual(metadata.sortName,
                           u'Campbell, Isobel & Lanegan, Mark')
-        self.assertEquals(metadata.release, u'2006-01-30')
-        self.assertEquals(metadata.mbidArtist,
+        self.assertEqual(metadata.release, u'2006-01-30')
+        self.assertEqual(metadata.mbidArtist,
                           u'd51f3a15-12a2-41a0-acfa-33b5eae71164;'
                           'a9126556-f555-4920-9617-6e013f8228a7')
 
-        self.assertEquals(len(metadata.tracks), 12)
+        self.assertEqual(len(metadata.tracks), 12)
 
         track12 = metadata.tracks[11]
 
-        self.assertEquals(track12.artist, u'Isobel Campbell & Mark Lanegan')
-        self.assertEquals(track12.sortName,
+        self.assertEqual(track12.artist, u'Isobel Campbell & Mark Lanegan')
+        self.assertEqual(track12.sortName,
                           u'Campbell, Isobel'
                           ' & Lanegan, Mark'
                           )
-        self.assertEquals(track12.mbidArtist,
+        self.assertEqual(track12.mbidArtist,
                           u'd51f3a15-12a2-41a0-acfa-33b5eae71164;'
                           'a9126556-f555-4920-9617-6e013f8228a7')
 
@@ -96,20 +96,20 @@ class MetadataTestCase(unittest.TestCase):
 
         metadata = mbngs._getMetadata({}, response['release'], discid)
 
-        self.assertEquals(metadata.artist, u'Mala')
-        self.assertEquals(metadata.sortName, u'Mala')
-        self.assertEquals(metadata.release, u'2012-09-17')
-        self.assertEquals(metadata.mbidArtist,
+        self.assertEqual(metadata.artist, u'Mala')
+        self.assertEqual(metadata.sortName, u'Mala')
+        self.assertEqual(metadata.release, u'2012-09-17')
+        self.assertEqual(metadata.mbidArtist,
                           u'09f221eb-c97e-4da5-ac22-d7ab7c555bbb')
 
-        self.assertEquals(len(metadata.tracks), 14)
+        self.assertEqual(len(metadata.tracks), 14)
 
         track6 = metadata.tracks[5]
 
-        self.assertEquals(track6.artist, u'Mala feat. Dreiser & Sexto Sentido')
-        self.assertEquals(track6.sortName,
+        self.assertEqual(track6.artist, u'Mala feat. Dreiser & Sexto Sentido')
+        self.assertEqual(track6.sortName,
                           u'Mala feat. Dreiser & Sexto Sentido')
-        self.assertEquals(track6.mbidArtist,
+        self.assertEqual(track6.mbidArtist,
                           u'09f221eb-c97e-4da5-ac22-d7ab7c555bbb'
                           ';ec07a209-55ff-4084-bc41-9d4d1764e075'
                           ';f626b92e-07b1-4a19-ad13-c09d690db66c'
@@ -130,29 +130,29 @@ class MetadataTestCase(unittest.TestCase):
         discid = "rzGHHqfPWIq1GsOLhhlBcZuqo.I-"
 
         metadata = mbngs._getMetadata({}, response['release'], discid)
-        self.assertEquals(metadata.artist, u'Various Artists')
-        self.assertEquals(metadata.release, u'2010')
-        self.assertEquals(metadata.mbidArtist,
+        self.assertEqual(metadata.artist, u'Various Artists')
+        self.assertEqual(metadata.release, u'2010')
+        self.assertEqual(metadata.mbidArtist,
                           u'89ad4ac3-39f7-470e-963a-56509c546377')
 
-        self.assertEquals(len(metadata.tracks), 10)
+        self.assertEqual(len(metadata.tracks), 10)
 
         track2 = metadata.tracks[1]
 
-        self.assertEquals(track2.artist, u'Twisted Reaction feat. Danielle')
-        self.assertEquals(track2.sortName,
+        self.assertEqual(track2.artist, u'Twisted Reaction feat. Danielle')
+        self.assertEqual(track2.sortName,
                           u'Twisted Reaction feat. [unknown]')
-        self.assertEquals(track2.mbidArtist,
+        self.assertEqual(track2.mbidArtist,
                           u'4f69f624-73ea-4a16-b822-bd2ca58032bf'
                           ';125ec42a-7229-4250-afc5-e057484327fe'
                           )
 
         track4 = metadata.tracks[3]
 
-        self.assertEquals(track4.artist, u'BioGenesis')
-        self.assertEquals(track4.sortName,
+        self.assertEqual(track4.artist, u'BioGenesis')
+        self.assertEqual(track4.sortName,
                           u'Bio Genesis')
-        self.assertEquals(track4.mbidArtist,
+        self.assertEqual(track4.mbidArtist,
                           u'dd61b86c-c015-43e1-9a28-58fceb0975c8'
                           )
 
@@ -169,26 +169,26 @@ class MetadataTestCase(unittest.TestCase):
         discid = "X2c2IQ5vUy5x6Jh7Xi_DGHtA1X8-"
 
         metadata = mbngs._getMetadata({}, response['release'], discid)
-        self.assertEquals(metadata.artist, u'Nena & Kim Wilde')
-        self.assertEquals(metadata.release, u'2003-05-19')
-        self.assertEquals(metadata.mbidArtist,
+        self.assertEqual(metadata.artist, u'Nena & Kim Wilde')
+        self.assertEqual(metadata.release, u'2003-05-19')
+        self.assertEqual(metadata.mbidArtist,
                           u'38bfaa7f-ee98-48cb-acd0-946d7aeecd76'
                           ';4b462375-c508-432a-8c88-ceeec38b16ae')
 
-        self.assertEquals(len(metadata.tracks), 4)
+        self.assertEqual(len(metadata.tracks), 4)
 
         track1 = metadata.tracks[0]
 
-        self.assertEquals(track1.artist, u'Nena & Kim Wilde')
-        self.assertEquals(track1.sortName, u'Nena & Wilde, Kim')
-        self.assertEquals(track1.mbidArtist,
+        self.assertEqual(track1.artist, u'Nena & Kim Wilde')
+        self.assertEqual(track1.sortName, u'Nena & Wilde, Kim')
+        self.assertEqual(track1.mbidArtist,
                           u'38bfaa7f-ee98-48cb-acd0-946d7aeecd76'
                           ';4b462375-c508-432a-8c88-ceeec38b16ae')
 
         track2 = metadata.tracks[1]
 
-        self.assertEquals(track2.artist, u'Nena & Kim Wilde')
-        self.assertEquals(track2.sortName, u'Nena & Wilde, Kim')
-        self.assertEquals(track2.mbidArtist,
+        self.assertEqual(track2.artist, u'Nena & Kim Wilde')
+        self.assertEqual(track2.sortName, u'Nena & Wilde, Kim')
+        self.assertEqual(track2.mbidArtist,
                           u'38bfaa7f-ee98-48cb-acd0-946d7aeecd76'
                           ';4b462375-c508-432a-8c88-ceeec38b16ae')

--- a/whipper/test/test_common_mbngs.py
+++ b/whipper/test/test_common_mbngs.py
@@ -38,7 +38,7 @@ class MetadataTestCase(unittest.TestCase):
         self.assertEqual(metadata.artist, u'Various Artists')
         self.assertEqual(metadata.release, u'2001-10-15')
         self.assertEqual(metadata.mbidArtist,
-                          u'89ad4ac3-39f7-470e-963a-56509c546377')
+                         u'89ad4ac3-39f7-470e-963a-56509c546377')
 
         self.assertEqual(len(metadata.tracks), 18)
 
@@ -46,11 +46,10 @@ class MetadataTestCase(unittest.TestCase):
 
         self.assertEqual(track16.artist, 'Tom Jones & Stereophonics')
         self.assertEqual(track16.mbidArtist,
-                          u'57c6f649-6cde-48a7-8114-2a200247601a'
-                          ';0bfba3d3-6a04-4779-bb0a-df07df5b0558'
-                          )
+                         u'57c6f649-6cde-48a7-8114-2a200247601a'
+                         ';0bfba3d3-6a04-4779-bb0a-df07df5b0558')
         self.assertEqual(track16.sortName,
-                          u'Jones, Tom & Stereophonics')
+                         u'Jones, Tom & Stereophonics')
 
     def testBalladOfTheBrokenSeas(self):
         # various artists disc
@@ -65,11 +64,11 @@ class MetadataTestCase(unittest.TestCase):
 
         self.assertEqual(metadata.artist, u'Isobel Campbell & Mark Lanegan')
         self.assertEqual(metadata.sortName,
-                          u'Campbell, Isobel & Lanegan, Mark')
+                         u'Campbell, Isobel & Lanegan, Mark')
         self.assertEqual(metadata.release, u'2006-01-30')
         self.assertEqual(metadata.mbidArtist,
-                          u'd51f3a15-12a2-41a0-acfa-33b5eae71164;'
-                          'a9126556-f555-4920-9617-6e013f8228a7')
+                         u'd51f3a15-12a2-41a0-acfa-33b5eae71164;'
+                         'a9126556-f555-4920-9617-6e013f8228a7')
 
         self.assertEqual(len(metadata.tracks), 12)
 
@@ -77,12 +76,11 @@ class MetadataTestCase(unittest.TestCase):
 
         self.assertEqual(track12.artist, u'Isobel Campbell & Mark Lanegan')
         self.assertEqual(track12.sortName,
-                          u'Campbell, Isobel'
-                          ' & Lanegan, Mark'
-                          )
+                         u'Campbell, Isobel'
+                         ' & Lanegan, Mark')
         self.assertEqual(track12.mbidArtist,
-                          u'd51f3a15-12a2-41a0-acfa-33b5eae71164;'
-                          'a9126556-f555-4920-9617-6e013f8228a7')
+                         u'd51f3a15-12a2-41a0-acfa-33b5eae71164;'
+                         'a9126556-f555-4920-9617-6e013f8228a7')
 
     def testMalaInCuba(self):
         # single artist disc, but with multiple artists tracks
@@ -100,7 +98,7 @@ class MetadataTestCase(unittest.TestCase):
         self.assertEqual(metadata.sortName, u'Mala')
         self.assertEqual(metadata.release, u'2012-09-17')
         self.assertEqual(metadata.mbidArtist,
-                          u'09f221eb-c97e-4da5-ac22-d7ab7c555bbb')
+                         u'09f221eb-c97e-4da5-ac22-d7ab7c555bbb')
 
         self.assertEqual(len(metadata.tracks), 14)
 
@@ -108,12 +106,11 @@ class MetadataTestCase(unittest.TestCase):
 
         self.assertEqual(track6.artist, u'Mala feat. Dreiser & Sexto Sentido')
         self.assertEqual(track6.sortName,
-                          u'Mala feat. Dreiser & Sexto Sentido')
+                         u'Mala feat. Dreiser & Sexto Sentido')
         self.assertEqual(track6.mbidArtist,
-                          u'09f221eb-c97e-4da5-ac22-d7ab7c555bbb'
-                          ';ec07a209-55ff-4084-bc41-9d4d1764e075'
-                          ';f626b92e-07b1-4a19-ad13-c09d690db66c'
-                          )
+                         u'09f221eb-c97e-4da5-ac22-d7ab7c555bbb'
+                         ';ec07a209-55ff-4084-bc41-9d4d1764e075'
+                         ';f626b92e-07b1-4a19-ad13-c09d690db66c')
 
     def testNorthernGateway(self):
         """
@@ -133,7 +130,7 @@ class MetadataTestCase(unittest.TestCase):
         self.assertEqual(metadata.artist, u'Various Artists')
         self.assertEqual(metadata.release, u'2010')
         self.assertEqual(metadata.mbidArtist,
-                          u'89ad4ac3-39f7-470e-963a-56509c546377')
+                         u'89ad4ac3-39f7-470e-963a-56509c546377')
 
         self.assertEqual(len(metadata.tracks), 10)
 
@@ -141,20 +138,18 @@ class MetadataTestCase(unittest.TestCase):
 
         self.assertEqual(track2.artist, u'Twisted Reaction feat. Danielle')
         self.assertEqual(track2.sortName,
-                          u'Twisted Reaction feat. [unknown]')
+                         u'Twisted Reaction feat. [unknown]')
         self.assertEqual(track2.mbidArtist,
-                          u'4f69f624-73ea-4a16-b822-bd2ca58032bf'
-                          ';125ec42a-7229-4250-afc5-e057484327fe'
-                          )
+                         u'4f69f624-73ea-4a16-b822-bd2ca58032bf'
+                         ';125ec42a-7229-4250-afc5-e057484327fe')
 
         track4 = metadata.tracks[3]
 
         self.assertEqual(track4.artist, u'BioGenesis')
         self.assertEqual(track4.sortName,
-                          u'Bio Genesis')
+                         u'Bio Genesis')
         self.assertEqual(track4.mbidArtist,
-                          u'dd61b86c-c015-43e1-9a28-58fceb0975c8'
-                          )
+                         u'dd61b86c-c015-43e1-9a28-58fceb0975c8')
 
     def testNenaAndKimWildSingle(self):
         """
@@ -172,8 +167,8 @@ class MetadataTestCase(unittest.TestCase):
         self.assertEqual(metadata.artist, u'Nena & Kim Wilde')
         self.assertEqual(metadata.release, u'2003-05-19')
         self.assertEqual(metadata.mbidArtist,
-                          u'38bfaa7f-ee98-48cb-acd0-946d7aeecd76'
-                          ';4b462375-c508-432a-8c88-ceeec38b16ae')
+                         u'38bfaa7f-ee98-48cb-acd0-946d7aeecd76'
+                         ';4b462375-c508-432a-8c88-ceeec38b16ae')
 
         self.assertEqual(len(metadata.tracks), 4)
 
@@ -182,13 +177,13 @@ class MetadataTestCase(unittest.TestCase):
         self.assertEqual(track1.artist, u'Nena & Kim Wilde')
         self.assertEqual(track1.sortName, u'Nena & Wilde, Kim')
         self.assertEqual(track1.mbidArtist,
-                          u'38bfaa7f-ee98-48cb-acd0-946d7aeecd76'
-                          ';4b462375-c508-432a-8c88-ceeec38b16ae')
+                         u'38bfaa7f-ee98-48cb-acd0-946d7aeecd76'
+                         ';4b462375-c508-432a-8c88-ceeec38b16ae')
 
         track2 = metadata.tracks[1]
 
         self.assertEqual(track2.artist, u'Nena & Kim Wilde')
         self.assertEqual(track2.sortName, u'Nena & Wilde, Kim')
         self.assertEqual(track2.mbidArtist,
-                          u'38bfaa7f-ee98-48cb-acd0-946d7aeecd76'
-                          ';4b462375-c508-432a-8c88-ceeec38b16ae')
+                         u'38bfaa7f-ee98-48cb-acd0-946d7aeecd76'
+                         ';4b462375-c508-432a-8c88-ceeec38b16ae')

--- a/whipper/test/test_common_path.py
+++ b/whipper/test/test_common_path.py
@@ -22,9 +22,9 @@ class FilterTestCase(common.TestCase):
     def testSpecial(self):
         part = u'<<< $&*!\' "()`{}[]spaceship>>>'
         self.assertEqual(self._filter.filter(part),
-                          u'___ _____ ________spaceship___')
+                         u'___ _____ ________spaceship___')
 
     def testGreatest(self):
         part = u'Greatest Ever! Soul: The Definitive Collection'
         self.assertEqual(self._filter.filter(part),
-                          u'Greatest Ever_ Soul - The Definitive Collection')
+                         u'Greatest Ever_ Soul - The Definitive Collection')

--- a/whipper/test/test_common_path.py
+++ b/whipper/test/test_common_path.py
@@ -13,18 +13,18 @@ class FilterTestCase(common.TestCase):
 
     def testSlash(self):
         part = u'A Charm/A Blade'
-        self.assertEquals(self._filter.filter(part), u'A Charm-A Blade')
+        self.assertEqual(self._filter.filter(part), u'A Charm-A Blade')
 
     def testFat(self):
         part = u'A Word: F**k you?'
-        self.assertEquals(self._filter.filter(part), u'A Word - F__k you_')
+        self.assertEqual(self._filter.filter(part), u'A Word - F__k you_')
 
     def testSpecial(self):
         part = u'<<< $&*!\' "()`{}[]spaceship>>>'
-        self.assertEquals(self._filter.filter(part),
+        self.assertEqual(self._filter.filter(part),
                           u'___ _____ ________spaceship___')
 
     def testGreatest(self):
         part = u'Greatest Ever! Soul: The Definitive Collection'
-        self.assertEquals(self._filter.filter(part),
+        self.assertEqual(self._filter.filter(part),
                           u'Greatest Ever_ Soul - The Definitive Collection')

--- a/whipper/test/test_common_program.py
+++ b/whipper/test/test_common_program.py
@@ -16,8 +16,8 @@ class PathTestCase(unittest.TestCase):
         path = prog.getPath(u'/tmp', DEFAULT_DISC_TEMPLATE,
                             'mbdiscid', None)
         self.assertEqual(path,
-                          unicode('/tmp/unknown/Unknown Artist - mbdiscid/'
-                                  'Unknown Artist - mbdiscid'))
+                         unicode('/tmp/unknown/Unknown Artist - mbdiscid/'
+                                 'Unknown Artist - mbdiscid'))
 
     def testStandardTemplateFilled(self):
         prog = program.Program(config.Config())
@@ -28,8 +28,8 @@ class PathTestCase(unittest.TestCase):
         path = prog.getPath(u'/tmp', DEFAULT_DISC_TEMPLATE,
                             'mbdiscid', md, 0)
         self.assertEqual(path,
-                          unicode('/tmp/unknown/Jeff Buckley - Grace/'
-                                  'Jeff Buckley - Grace'))
+                         unicode('/tmp/unknown/Jeff Buckley - Grace/'
+                                 'Jeff Buckley - Grace'))
 
     def testIssue66TemplateFilled(self):
         prog = program.Program(config.Config())
@@ -39,4 +39,4 @@ class PathTestCase(unittest.TestCase):
 
         path = prog.getPath(u'/tmp', u'%A/%d', 'mbdiscid', md, 0)
         self.assertEqual(path,
-                          u'/tmp/Jeff Buckley/Grace')
+                         u'/tmp/Jeff Buckley/Grace')

--- a/whipper/test/test_common_program.py
+++ b/whipper/test/test_common_program.py
@@ -15,7 +15,7 @@ class PathTestCase(unittest.TestCase):
 
         path = prog.getPath(u'/tmp', DEFAULT_DISC_TEMPLATE,
                             'mbdiscid', None)
-        self.assertEquals(path,
+        self.assertEqual(path,
                           unicode('/tmp/unknown/Unknown Artist - mbdiscid/'
                                   'Unknown Artist - mbdiscid'))
 
@@ -27,7 +27,7 @@ class PathTestCase(unittest.TestCase):
 
         path = prog.getPath(u'/tmp', DEFAULT_DISC_TEMPLATE,
                             'mbdiscid', md, 0)
-        self.assertEquals(path,
+        self.assertEqual(path,
                           unicode('/tmp/unknown/Jeff Buckley - Grace/'
                                   'Jeff Buckley - Grace'))
 
@@ -38,5 +38,5 @@ class PathTestCase(unittest.TestCase):
         md.title = 'Grace'
 
         path = prog.getPath(u'/tmp', u'%A/%d', 'mbdiscid', md, 0)
-        self.assertEquals(path,
+        self.assertEqual(path,
                           u'/tmp/Jeff Buckley/Grace')

--- a/whipper/test/test_common_renamer.py
+++ b/whipper/test/test_common_renamer.py
@@ -114,7 +114,7 @@ class OperatorTestCase(unittest.TestCase):
     def testLoadOneDone(self):
         self.assertEqual(len(self._operator._done), 0)
         self._operator.save()
-        self._operator.next()
+        next(self._operator)
         self.assertEqual(len(self._operator._done), 1)
 
         o = renamer.Operator(self._statePath, 'test')
@@ -125,7 +125,7 @@ class OperatorTestCase(unittest.TestCase):
         self.assertEqual(o._done, self._operator._done)
 
         # now continue
-        o.next()
+        next(o)
         self.assertEqual(len(o._done), 2)
         os.unlink(self._destination)
 
@@ -146,9 +146,9 @@ class OperatorTestCase(unittest.TestCase):
         self.assertEqual(o._done, self._operator._done)
 
         # now continue, resuming
-        o.next()
+        next(o)
         self.assertEqual(len(o._done), 1)
-        o.next()
+        next(o)
         self.assertEqual(len(o._done), 2)
 
         os.unlink(self._destination)

--- a/whipper/test/test_common_renamer.py
+++ b/whipper/test/test_common_renamer.py
@@ -18,7 +18,7 @@ class RenameInFileTestcase(unittest.TestCase):
 
     def testVerify(self):
         o = renamer.RenameInFile(self._path, 'is is a', 'at was some')
-        self.assertEquals(o.verify(), None)
+        self.assertEqual(o.verify(), None)
         os.unlink(self._path)
         self.assertRaises(AssertionError, o.verify)
 
@@ -26,7 +26,7 @@ class RenameInFileTestcase(unittest.TestCase):
         o = renamer.RenameInFile(self._path, 'is is a', 'at was some')
         o.do()
         output = open(self._path).read()
-        self.assertEquals(output, 'That was some test\nThat was somenother\n')
+        self.assertEqual(output, 'That was some test\nThat was somenother\n')
         os.unlink(self._path)
 
     def testSerialize(self):
@@ -35,7 +35,7 @@ class RenameInFileTestcase(unittest.TestCase):
         o2 = renamer.RenameInFile.deserialize(data)
         o2.do()
         output = open(self._path).read()
-        self.assertEquals(output, 'That was some test\nThat was somenother\n')
+        self.assertEqual(output, 'That was some test\nThat was somenother\n')
         os.unlink(self._path)
 
 
@@ -52,14 +52,14 @@ class RenameFileTestcase(unittest.TestCase):
         self._operation = renamer.RenameFile(self._source, self._destination)
 
     def testVerify(self):
-        self.assertEquals(self._operation.verify(), None)
+        self.assertEqual(self._operation.verify(), None)
 
         handle = open(self._destination, 'w')
         handle.close()
         self.assertRaises(AssertionError, self._operation.verify)
 
         os.unlink(self._destination)
-        self.assertEquals(self._operation.verify(), None)
+        self.assertEqual(self._operation.verify(), None)
 
         os.unlink(self._source)
         self.assertRaises(AssertionError, self._operation.verify)
@@ -67,7 +67,7 @@ class RenameFileTestcase(unittest.TestCase):
     def testDo(self):
         self._operation.do()
         output = open(self._destination).read()
-        self.assertEquals(output, 'This is a test\nThis is another\n')
+        self.assertEqual(output, 'This is a test\nThis is another\n')
         os.unlink(self._destination)
 
     def testSerialize(self):
@@ -75,7 +75,7 @@ class RenameFileTestcase(unittest.TestCase):
         o = renamer.RenameFile.deserialize(data)
         o.do()
         output = open(self._destination).read()
-        self.assertEquals(output, 'This is a test\nThis is another\n')
+        self.assertEqual(output, 'This is a test\nThis is another\n')
         os.unlink(self._destination)
 
 
@@ -107,48 +107,48 @@ class OperatorTestCase(unittest.TestCase):
         o = renamer.Operator(self._statePath, 'test')
         o.load()
 
-        self.assertEquals(o._todo, self._operator._todo)
-        self.assertEquals(o._done, [])
+        self.assertEqual(o._todo, self._operator._todo)
+        self.assertEqual(o._done, [])
         os.unlink(self._source)
 
     def testLoadOneDone(self):
-        self.assertEquals(len(self._operator._done), 0)
+        self.assertEqual(len(self._operator._done), 0)
         self._operator.save()
         self._operator.next()
-        self.assertEquals(len(self._operator._done), 1)
+        self.assertEqual(len(self._operator._done), 1)
 
         o = renamer.Operator(self._statePath, 'test')
         o.load()
 
-        self.assertEquals(len(o._done), 1)
-        self.assertEquals(o._todo, self._operator._todo)
-        self.assertEquals(o._done, self._operator._done)
+        self.assertEqual(len(o._done), 1)
+        self.assertEqual(o._todo, self._operator._todo)
+        self.assertEqual(o._done, self._operator._done)
 
         # now continue
         o.next()
-        self.assertEquals(len(o._done), 2)
+        self.assertEqual(len(o._done), 2)
         os.unlink(self._destination)
 
     def testLoadOneInterrupted(self):
-        self.assertEquals(len(self._operator._done), 0)
+        self.assertEqual(len(self._operator._done), 0)
         self._operator.save()
 
         # cheat by doing a task without saving
         self._operator._todo[0].do()
 
-        self.assertEquals(len(self._operator._done), 0)
+        self.assertEqual(len(self._operator._done), 0)
 
         o = renamer.Operator(self._statePath, 'test')
         o.load()
 
-        self.assertEquals(len(o._done), 0)
-        self.assertEquals(o._todo, self._operator._todo)
-        self.assertEquals(o._done, self._operator._done)
+        self.assertEqual(len(o._done), 0)
+        self.assertEqual(o._todo, self._operator._todo)
+        self.assertEqual(o._done, self._operator._done)
 
         # now continue, resuming
         o.next()
-        self.assertEquals(len(o._done), 1)
+        self.assertEqual(len(o._done), 1)
         o.next()
-        self.assertEquals(len(o._done), 2)
+        self.assertEqual(len(o._done), 2)
 
         os.unlink(self._destination)

--- a/whipper/test/test_image_cue.py
+++ b/whipper/test/test_image_cue.py
@@ -18,14 +18,14 @@ class KingsSingleTestCase(unittest.TestCase):
         self.cue = cue.CueFile(os.path.join(os.path.dirname(__file__),
                                             u'kings-single.cue'))
         self.cue.parse()
-        self.assertEquals(len(self.cue.table.tracks), 11)
+        self.assertEqual(len(self.cue.table.tracks), 11)
 
     def testGetTrackLength(self):
         t = self.cue.table.tracks[0]
-        self.assertEquals(self.cue.getTrackLength(t), 17811)
+        self.assertEqual(self.cue.getTrackLength(t), 17811)
         # last track has unknown length
         t = self.cue.table.tracks[-1]
-        self.assertEquals(self.cue.getTrackLength(t), -1)
+        self.assertEqual(self.cue.getTrackLength(t), -1)
 
 
 class KingsSeparateTestCase(unittest.TestCase):
@@ -34,14 +34,14 @@ class KingsSeparateTestCase(unittest.TestCase):
         self.cue = cue.CueFile(os.path.join(os.path.dirname(__file__),
                                             u'kings-separate.cue'))
         self.cue.parse()
-        self.assertEquals(len(self.cue.table.tracks), 11)
+        self.assertEqual(len(self.cue.table.tracks), 11)
 
     def testGetTrackLength(self):
         # all tracks have unknown length
         t = self.cue.table.tracks[0]
-        self.assertEquals(self.cue.getTrackLength(t), -1)
+        self.assertEqual(self.cue.getTrackLength(t), -1)
         t = self.cue.table.tracks[-1]
-        self.assertEquals(self.cue.getTrackLength(t), -1)
+        self.assertEqual(self.cue.getTrackLength(t), -1)
 
 
 class KanyeMixedTestCase(unittest.TestCase):
@@ -50,11 +50,11 @@ class KanyeMixedTestCase(unittest.TestCase):
         self.cue = cue.CueFile(os.path.join(os.path.dirname(__file__),
                                             u'kanye.cue'))
         self.cue.parse()
-        self.assertEquals(len(self.cue.table.tracks), 13)
+        self.assertEqual(len(self.cue.table.tracks), 13)
 
     def testGetTrackLength(self):
         t = self.cue.table.tracks[0]
-        self.assertEquals(self.cue.getTrackLength(t), -1)
+        self.assertEqual(self.cue.getTrackLength(t), -1)
 
 
 class WriteCueFileTestCase(unittest.TestCase):

--- a/whipper/test/test_image_table.py
+++ b/whipper/test/test_image_table.py
@@ -59,13 +59,13 @@ class LadyhawkeTestCase(tcommon.TestCase):
         # however, not (yet) in MusicBrainz database
 
         self.assertEqual(self.table.getMusicBrainzDiscId(),
-                          "KnpGsLhvH.lPrNc1PBL21lb9Bg4-")
+                         "KnpGsLhvH.lPrNc1PBL21lb9Bg4-")
 
     def testAccurateRip(self):
         self.assertEqual(self.table.accuraterip_ids(), (
             "0013bd5a", "00b8d489"))
         self.assertEqual(self.table.accuraterip_path(),
-                          "a/5/d/dBAR-012-0013bd5a-00b8d489-c60af50d.bin")
+                         "a/5/d/dBAR-012-0013bd5a-00b8d489-c60af50d.bin")
 
     def testDuration(self):
         self.assertEqual(self.table.duration(), 2761413)
@@ -94,7 +94,7 @@ class MusicBrainzTestCase(tcommon.TestCase):
 
     def testMusicBrainz(self):
         self.assertEqual(self.table.getMusicBrainzDiscId(),
-                          '49HHV7Eb8UKF3aQiNmu1GR8vKTY-')
+                         '49HHV7Eb8UKF3aQiNmu1GR8vKTY-')
 
 
 class PregapTestCase(tcommon.TestCase):

--- a/whipper/test/test_image_table.py
+++ b/whipper/test/test_image_table.py
@@ -14,10 +14,10 @@ class TrackTestCase(tcommon.TestCase):
 
     def testRepr(self):
         track = table.Track(1)
-        self.assertEquals(repr(track), "<Track 01>")
+        self.assertEqual(repr(track), "<Track 01>")
 
         track.index(1, 100)
-        self.failUnless(repr(track.indexes[1]).startswith('<Index 01 '))
+        self.assertTrue(repr(track.indexes[1]).startswith('<Index 01 '))
 
 
 class LadyhawkeTestCase(tcommon.TestCase):
@@ -41,15 +41,15 @@ class LadyhawkeTestCase(tcommon.TestCase):
         for i, offset in enumerate(offsets):
             t[i].index(1, absolute=offset)
 
-        self.failIf(self.table.hasTOC())
+        self.assertFalse(self.table.hasTOC())
 
         self.table.leadout = 210385
 
-        self.failUnless(self.table.hasTOC())
-        self.assertEquals(self.table.tracks[0].getPregap(), 0)
+        self.assertTrue(self.table.hasTOC())
+        self.assertEqual(self.table.tracks[0].getPregap(), 0)
 
     def testCDDB(self):
-        self.assertEquals(self.table.getCDDBDiscId(), "c60af50d")
+        self.assertEqual(self.table.getCDDBDiscId(), "c60af50d")
 
     def testMusicBrainz(self):
         # output from mb-submit-disc:
@@ -58,17 +58,17 @@ class LadyhawkeTestCase(tcommon.TestCase):
         # 177832&tracks=12&id=KnpGsLhvH.lPrNc1PBL21lb9Bg4-
         # however, not (yet) in MusicBrainz database
 
-        self.assertEquals(self.table.getMusicBrainzDiscId(),
+        self.assertEqual(self.table.getMusicBrainzDiscId(),
                           "KnpGsLhvH.lPrNc1PBL21lb9Bg4-")
 
     def testAccurateRip(self):
-        self.assertEquals(self.table.accuraterip_ids(), (
+        self.assertEqual(self.table.accuraterip_ids(), (
             "0013bd5a", "00b8d489"))
-        self.assertEquals(self.table.accuraterip_path(),
+        self.assertEqual(self.table.accuraterip_path(),
                           "a/5/d/dBAR-012-0013bd5a-00b8d489-c60af50d.bin")
 
     def testDuration(self):
-        self.assertEquals(self.table.duration(), 2761413)
+        self.assertEqual(self.table.duration(), 2761413)
 
 
 class MusicBrainzTestCase(tcommon.TestCase):
@@ -86,14 +86,14 @@ class MusicBrainzTestCase(tcommon.TestCase):
         for i, offset in enumerate(offsets):
             t[i].index(1, absolute=offset)
 
-        self.failIf(self.table.hasTOC())
+        self.assertFalse(self.table.hasTOC())
 
         self.table.leadout = 95312
 
-        self.failUnless(self.table.hasTOC())
+        self.assertTrue(self.table.hasTOC())
 
     def testMusicBrainz(self):
-        self.assertEquals(self.table.getMusicBrainzDiscId(),
+        self.assertEqual(self.table.getMusicBrainzDiscId(),
                           '49HHV7Eb8UKF3aQiNmu1GR8vKTY-')
 
 
@@ -112,5 +112,5 @@ class PregapTestCase(tcommon.TestCase):
         t[1].index(0, offsets[1] - 200)
 
     def testPreGap(self):
-        self.assertEquals(self.table.tracks[0].getPregap(), 0)
-        self.assertEquals(self.table.tracks[1].getPregap(), 200)
+        self.assertEqual(self.table.tracks[0].getPregap(), 0)
+        self.assertEqual(self.table.tracks[1].getPregap(), 200)

--- a/whipper/test/test_image_toc.py
+++ b/whipper/test/test_image_toc.py
@@ -25,7 +25,7 @@ class CureTestCase(common.TestCase):
         # its length is all of track 1 from .toc, plus the INDEX 00 length
         # of track 2
         self.assertEqual(self.toc.getTrackLength(t),
-                          (((6 * 60) + 16) * 75 + 45) + ((1 * 75) + 4))
+                         (((6 * 60) + 16) * 75 + 45) + ((1 * 75) + 4))
         # last track has unknown length
         t = self.toc.table.tracks[-1]
         self.assertEqual(self.toc.getTrackLength(t), -1)
@@ -90,7 +90,7 @@ class CureTestCase(common.TestCase):
 
         # we verify it because it has failed in readdisc in the past
         self.assertEqual(self.toc.table.accuraterip_path(),
-                          '3/c/4/dBAR-013-0019d4c3-00fe8924-b90c650d.bin')
+                         '3/c/4/dBAR-013-0019d4c3-00fe8924-b90c650d.bin')
 
     def testGetRealPath(self):
         self.assertRaises(KeyError, self.toc.getRealPath, u'track01.wav')
@@ -165,7 +165,7 @@ class BlocTestCase(common.TestCase):
     def testAccurateRip(self):
         # we verify it because it has failed in readdisc in the past
         self.assertEqual(self.toc.table.accuraterip_path(),
-                          'e/d/2/dBAR-013-001af2de-0105994e-ad0be00d.bin')
+                         'e/d/2/dBAR-013-001af2de-0105994e-ad0be00d.bin')
 
 # The Breeders - Mountain Battles has CDText
 
@@ -214,7 +214,7 @@ class LadyhawkeTestCase(common.TestCase):
 
     def testMusicBrainz(self):
         self.assertEqual(self.toc.table.getMusicBrainzDiscId(),
-                          "KnpGsLhvH.lPrNc1PBL21lb9Bg4-")
+                         "KnpGsLhvH.lPrNc1PBL21lb9Bg4-")
         self.assertEqual(self.toc.table.getMusicBrainzSubmitURL(),
             "https://musicbrainz.org/cdtoc/attach?toc=1+12+195856+150+15687+31841+51016+66616+81352+99559+116070+133243+149997+161710+177832&tracks=12&id=KnpGsLhvH.lPrNc1PBL21lb9Bg4-")  # noqa: E501
 
@@ -262,7 +262,7 @@ class CapitalMergeTestCase(common.TestCase):
         # 197850+24320+44855+64090+77885+88095+104020+118245+129255+141765+
         # 164487+181780&tracks=11&id=MAj3xXf6QMy7G.BIFOyHyq4MySE-
         self.assertEqual(self.table.getMusicBrainzDiscId(),
-                          "MAj3xXf6QMy7G.BIFOyHyq4MySE-")
+                         "MAj3xXf6QMy7G.BIFOyHyq4MySE-")
 
     def testDuration(self):
         # this matches track 11 end sector - track 1 start sector on

--- a/whipper/test/test_image_toc.py
+++ b/whipper/test/test_image_toc.py
@@ -17,18 +17,18 @@ class CureTestCase(common.TestCase):
         self.path = os.path.join(os.path.dirname(__file__), u'cure.toc')
         self.toc = toc.TocFile(self.path)
         self.toc.parse()
-        self.assertEquals(len(self.toc.table.tracks), 13)
+        self.assertEqual(len(self.toc.table.tracks), 13)
 
     def testGetTrackLength(self):
         t = self.toc.table.tracks[0]
         # first track has known length because the .toc is a single file
         # its length is all of track 1 from .toc, plus the INDEX 00 length
         # of track 2
-        self.assertEquals(self.toc.getTrackLength(t),
+        self.assertEqual(self.toc.getTrackLength(t),
                           (((6 * 60) + 16) * 75 + 45) + ((1 * 75) + 4))
         # last track has unknown length
         t = self.toc.table.tracks[-1]
-        self.assertEquals(self.toc.getTrackLength(t), -1)
+        self.assertEqual(self.toc.getTrackLength(t), -1)
 
     def testIndexes(self):
         # track 2, index 0 is at 06:16:45 or 28245
@@ -36,8 +36,8 @@ class CureTestCase(common.TestCase):
         # FIXME: cdrdao seems to get length of FILE 1 frame too many,
         # and START value one frame less
         t = self.toc.table.tracks[1]
-        self.assertEquals(t.getIndex(0).relative, 28245)
-        self.assertEquals(t.getIndex(1).relative, 28324)
+        self.assertEqual(t.getIndex(0).relative, 28245)
+        self.assertEqual(t.getIndex(1).relative, 28324)
 
     def _getIndex(self, t, i):
         track = self.toc.table.tracks[t - 1]
@@ -45,15 +45,15 @@ class CureTestCase(common.TestCase):
 
     def _assertAbsolute(self, t, i, value):
         index = self._getIndex(t, i)
-        self.assertEquals(index.absolute, value)
+        self.assertEqual(index.absolute, value)
 
     def _assertPath(self, t, i, value):
         index = self._getIndex(t, i)
-        self.assertEquals(index.path, value)
+        self.assertEqual(index.path, value)
 
     def _assertRelative(self, t, i, value):
         index = self._getIndex(t, i)
-        self.assertEquals(index.relative, value)
+        self.assertEqual(index.relative, value)
 
     def testSetFile(self):
         self._assertAbsolute(1, 1, 0)
@@ -89,16 +89,16 @@ class CureTestCase(common.TestCase):
         common.diffStrings(ref, cue)
 
         # we verify it because it has failed in readdisc in the past
-        self.assertEquals(self.toc.table.accuraterip_path(),
+        self.assertEqual(self.toc.table.accuraterip_path(),
                           '3/c/4/dBAR-013-0019d4c3-00fe8924-b90c650d.bin')
 
     def testGetRealPath(self):
         self.assertRaises(KeyError, self.toc.getRealPath, u'track01.wav')
         (fd, path) = tempfile.mkstemp(suffix=u'.whipper.test.wav')
-        self.assertEquals(self.toc.getRealPath(path), path)
+        self.assertEqual(self.toc.getRealPath(path), path)
 
         winpath = path.replace('/', '\\')
-        self.assertEquals(self.toc.getRealPath(winpath), path)
+        self.assertEqual(self.toc.getRealPath(winpath), path)
         os.close(fd)
         os.unlink(path)
 
@@ -111,46 +111,46 @@ class BlocTestCase(common.TestCase):
         self.path = os.path.join(os.path.dirname(__file__), u'bloc.toc')
         self.toc = toc.TocFile(self.path)
         self.toc.parse()
-        self.assertEquals(len(self.toc.table.tracks), 13)
+        self.assertEqual(len(self.toc.table.tracks), 13)
 
     def testGetTrackLength(self):
         t = self.toc.table.tracks[0]
         # first track has known length because the .toc is a single file
         # the length is from Track 1, Index 1 to Track 2, Index 1, so
         # does not include the htoa
-        self.assertEquals(self.toc.getTrackLength(t), 19649)
+        self.assertEqual(self.toc.getTrackLength(t), 19649)
         # last track has unknown length
         t = self.toc.table.tracks[-1]
-        self.assertEquals(self.toc.getTrackLength(t), -1)
+        self.assertEqual(self.toc.getTrackLength(t), -1)
 
     def testIndexes(self):
         track01 = self.toc.table.tracks[0]
         index00 = track01.getIndex(0)
-        self.assertEquals(index00.absolute, 0)
-        self.assertEquals(index00.relative, 0)
-        self.assertEquals(index00.counter, 0)
+        self.assertEqual(index00.absolute, 0)
+        self.assertEqual(index00.relative, 0)
+        self.assertEqual(index00.counter, 0)
 
         index01 = track01.getIndex(1)
-        self.assertEquals(index01.absolute, 15220)
-        self.assertEquals(index01.relative, 0)
-        self.assertEquals(index01.counter, 1)
+        self.assertEqual(index01.absolute, 15220)
+        self.assertEqual(index01.relative, 0)
+        self.assertEqual(index01.counter, 1)
 
         track05 = self.toc.table.tracks[4]
 
         index00 = track05.getIndex(0)
-        self.assertEquals(index00.absolute, 84070)
-        self.assertEquals(index00.relative, 68850)
-        self.assertEquals(index00.counter, 1)
+        self.assertEqual(index00.absolute, 84070)
+        self.assertEqual(index00.relative, 68850)
+        self.assertEqual(index00.counter, 1)
 
         index01 = track05.getIndex(1)
-        self.assertEquals(index01.absolute, 84142)
-        self.assertEquals(index01.relative, 68922)
-        self.assertEquals(index01.counter, 1)
+        self.assertEqual(index01.absolute, 84142)
+        self.assertEqual(index01.relative, 68922)
+        self.assertEqual(index01.counter, 1)
 
     # This disc has a pre-gap, so is a good test for .CUE writing
 
     def testConvertCue(self):
-        self.failUnless(self.toc.table.hasTOC())
+        self.assertTrue(self.toc.table.hasTOC())
         cue = self.toc.table.cue()
         ref = self.readCue('bloc.cue')
         common.diffStrings(ref, cue)
@@ -160,11 +160,11 @@ class BlocTestCase(common.TestCase):
         # ad0be00d 13 15370 35019 51532 69190 84292 96826 112527 132448
         # 148595 168072 185539 203331 222103 3244
 
-        self.assertEquals(self.toc.table.getCDDBDiscId(), 'ad0be00d')
+        self.assertEqual(self.toc.table.getCDDBDiscId(), 'ad0be00d')
 
     def testAccurateRip(self):
         # we verify it because it has failed in readdisc in the past
-        self.assertEquals(self.toc.table.accuraterip_path(),
+        self.assertEqual(self.toc.table.accuraterip_path(),
                           'e/d/2/dBAR-013-001af2de-0105994e-ad0be00d.bin')
 
 # The Breeders - Mountain Battles has CDText
@@ -176,23 +176,23 @@ class BreedersTestCase(common.TestCase):
         self.path = os.path.join(os.path.dirname(__file__), u'breeders.toc')
         self.toc = toc.TocFile(self.path)
         self.toc.parse()
-        self.assertEquals(len(self.toc.table.tracks), 13)
+        self.assertEqual(len(self.toc.table.tracks), 13)
 
     def testCDText(self):
         cdt = self.toc.table.cdtext
-        self.assertEquals(cdt['PERFORMER'], 'THE BREEDERS')
-        self.assertEquals(cdt['TITLE'], 'MOUNTAIN BATTLES')
+        self.assertEqual(cdt['PERFORMER'], 'THE BREEDERS')
+        self.assertEqual(cdt['TITLE'], 'MOUNTAIN BATTLES')
 
         t = self.toc.table.tracks[0]
         cdt = t.cdtext
         self.assertRaises(AttributeError, getattr, cdt, 'PERFORMER')
-        self.assertEquals(cdt['TITLE'], 'OVERGLAZED')
+        self.assertEqual(cdt['TITLE'], 'OVERGLAZED')
 
     def testConvertCue(self):
-        self.failUnless(self.toc.table.hasTOC())
+        self.assertTrue(self.toc.table.hasTOC())
         cue = self.toc.table.cue()
         ref = self.readCue('breeders.cue')
-        self.assertEquals(cue, ref)
+        self.assertEqual(cue, ref)
 
 # Ladyhawke has a data track
 
@@ -203,34 +203,34 @@ class LadyhawkeTestCase(common.TestCase):
         self.path = os.path.join(os.path.dirname(__file__), u'ladyhawke.toc')
         self.toc = toc.TocFile(self.path)
         self.toc.parse()
-        self.assertEquals(len(self.toc.table.tracks), 13)
-        self.failIf(self.toc.table.tracks[-1].audio)
+        self.assertEqual(len(self.toc.table.tracks), 13)
+        self.assertFalse(self.toc.table.tracks[-1].audio)
 
     def testCDDBId(self):
-        self.assertEquals(self.toc.table.getCDDBDiscId(), 'c60af50d')
+        self.assertEqual(self.toc.table.getCDDBDiscId(), 'c60af50d')
         # output from cd-discid:
         # c60af50d 13 150 15687 31841 51016 66616 81352 99559 116070 133243
         # 149997 161710 177832 207256 2807
 
     def testMusicBrainz(self):
-        self.assertEquals(self.toc.table.getMusicBrainzDiscId(),
+        self.assertEqual(self.toc.table.getMusicBrainzDiscId(),
                           "KnpGsLhvH.lPrNc1PBL21lb9Bg4-")
-        self.assertEquals(self.toc.table.getMusicBrainzSubmitURL(),
+        self.assertEqual(self.toc.table.getMusicBrainzSubmitURL(),
             "https://musicbrainz.org/cdtoc/attach?toc=1+12+195856+150+15687+31841+51016+66616+81352+99559+116070+133243+149997+161710+177832&tracks=12&id=KnpGsLhvH.lPrNc1PBL21lb9Bg4-")  # noqa: E501
 
     # FIXME: I don't trust this toc, but I can't find the CD anymore
 
     def testDuration(self):
-        self.assertEquals(self.toc.table.duration(), 2761413)
+        self.assertEqual(self.toc.table.duration(), 2761413)
 
     def testGetFrameLength(self):
-        self.assertEquals(self.toc.table.getFrameLength(data=True), 210385)
+        self.assertEqual(self.toc.table.getFrameLength(data=True), 210385)
 
     def testCue(self):
-        self.failUnless(self.toc.table.canCue())
+        self.assertTrue(self.toc.table.canCue())
         data = self.toc.table.cue()
         lines = data.split("\n")
-        self.assertEquals(lines[0], "REM DISCID C60AF50D")
+        self.assertEqual(lines[0], "REM DISCID C60AF50D")
 
 
 class CapitalMergeTestCase(common.TestCase):
@@ -239,20 +239,20 @@ class CapitalMergeTestCase(common.TestCase):
         self.toc1 = toc.TocFile(os.path.join(os.path.dirname(__file__),
                                              u'capital.1.toc'))
         self.toc1.parse()
-        self.assertEquals(len(self.toc1.table.tracks), 11)
-        self.failUnless(self.toc1.table.tracks[-1].audio)
+        self.assertEqual(len(self.toc1.table.tracks), 11)
+        self.assertTrue(self.toc1.table.tracks[-1].audio)
 
         self.toc2 = toc.TocFile(os.path.join(os.path.dirname(__file__),
                                              u'capital.2.toc'))
         self.toc2.parse()
-        self.assertEquals(len(self.toc2.table.tracks), 1)
-        self.failIf(self.toc2.table.tracks[-1].audio)
+        self.assertEqual(len(self.toc2.table.tracks), 1)
+        self.assertFalse(self.toc2.table.tracks[-1].audio)
 
         self.table = copy.deepcopy(self.toc1.table)
         self.table.merge(self.toc2.table)
 
     def testCDDBId(self):
-        self.assertEquals(self.table.getCDDBDiscId(), 'b910140c')
+        self.assertEqual(self.table.getCDDBDiscId(), 'b910140c')
         # output from cd-discid:
         # b910140c 12 24320 44855 64090 77885 88095 104020 118245 129255 141765
         # 164487 181780 209250 4440
@@ -261,15 +261,15 @@ class CapitalMergeTestCase(common.TestCase):
         # URL to submit: https://musicbrainz.org/cdtoc/attach?toc=1+11+
         # 197850+24320+44855+64090+77885+88095+104020+118245+129255+141765+
         # 164487+181780&tracks=11&id=MAj3xXf6QMy7G.BIFOyHyq4MySE-
-        self.assertEquals(self.table.getMusicBrainzDiscId(),
+        self.assertEqual(self.table.getMusicBrainzDiscId(),
                           "MAj3xXf6QMy7G.BIFOyHyq4MySE-")
 
     def testDuration(self):
         # this matches track 11 end sector - track 1 start sector on
         # MusicBrainz
         # compare to 3rd and 4th value in URL above
-        self.assertEquals(self.table.getFrameLength(), 173530)
-        self.assertEquals(self.table.duration(), 2313733)
+        self.assertEqual(self.table.getFrameLength(), 173530)
+        self.assertEqual(self.table.duration(), 2313733)
 
 
 class UnicodeTestCase(common.TestCase, common.UnicodeTestMixin):
@@ -286,7 +286,7 @@ class UnicodeTestCase(common.TestCase, common.UnicodeTestMixin):
         shutil.copy(source, self.dest)
         self.toc = toc.TocFile(self.dest)
         self.toc.parse()
-        self.assertEquals(len(self.toc.table.tracks), 10)
+        self.assertEqual(len(self.toc.table.tracks), 10)
 
     def tearDown(self):
         os.unlink(self.dest)
@@ -294,14 +294,14 @@ class UnicodeTestCase(common.TestCase, common.UnicodeTestMixin):
     def testGetTrackLength(self):
         t = self.toc.table.tracks[0]
         # first track has known length because the .toc is a single file
-        self.assertEquals(self.toc.getTrackLength(t), 12001)
+        self.assertEqual(self.toc.getTrackLength(t), 12001)
         # last track has unknown length
         t = self.toc.table.tracks[-1]
-        self.assertEquals(self.toc.getTrackLength(t), -1)
+        self.assertEqual(self.toc.getTrackLength(t), -1)
 
     def testGetTrackPerformer(self):
         t = self.toc.table.tracks[0]
-        self.assertEquals(t.cdtext['PERFORMER'], self._performer)
+        self.assertEqual(t.cdtext['PERFORMER'], self._performer)
 
 
 # Interpol - Turn of the Bright Lights has same cddb disc id as
@@ -314,10 +314,10 @@ class TOTBLTestCase(common.TestCase):
         self.path = os.path.join(os.path.dirname(__file__), u'totbl.fast.toc')
         self.toc = toc.TocFile(self.path)
         self.toc.parse()
-        self.assertEquals(len(self.toc.table.tracks), 11)
+        self.assertEqual(len(self.toc.table.tracks), 11)
 
     def testCDDBId(self):
-        self.assertEquals(self.toc.table.getCDDBDiscId(), '810b7b0b')
+        self.assertEqual(self.toc.table.getCDDBDiscId(), '810b7b0b')
 
 
 # The Strokes - Someday has a 1 frame SILENCE marked as such in toc
@@ -330,21 +330,21 @@ class StrokesTestCase(common.TestCase):
                                  u'strokes-someday.toc')
         self.toc = toc.TocFile(self.path)
         self.toc.parse()
-        self.assertEquals(len(self.toc.table.tracks), 1)
+        self.assertEqual(len(self.toc.table.tracks), 1)
 
     def testIndexes(self):
         t = self.toc.table.tracks[0]
         i0 = t.getIndex(0)
-        self.assertEquals(i0.relative, 0)
-        self.assertEquals(i0.absolute, 0)
-        self.assertEquals(i0.counter, 0)
-        self.assertEquals(i0.path, None)
+        self.assertEqual(i0.relative, 0)
+        self.assertEqual(i0.absolute, 0)
+        self.assertEqual(i0.counter, 0)
+        self.assertEqual(i0.path, None)
 
         i1 = t.getIndex(1)
-        self.assertEquals(i1.relative, 0)
-        self.assertEquals(i1.absolute, 1)
-        self.assertEquals(i1.counter, 1)
-        self.assertEquals(i1.path, u'data.wav')
+        self.assertEqual(i1.relative, 0)
+        self.assertEqual(i1.absolute, 1)
+        self.assertEqual(i1.counter, 1)
+        self.assertEqual(i1.path, u'data.wav')
 
         cue = self._filterCue(self.toc.table.cue())
         ref = self._filterCue(
@@ -388,32 +388,32 @@ class SurferRosaTestCase(common.TestCase):
         self.path = os.path.join(os.path.dirname(__file__), u'surferrosa.toc')
         self.toc = toc.TocFile(self.path)
         self.toc.parse()
-        self.assertEquals(len(self.toc.table.tracks), 21)
+        self.assertEqual(len(self.toc.table.tracks), 21)
 
     def testIndexes(self):
         # HTOA
         t = self.toc.table.tracks[0]
-        self.assertEquals(len(t.indexes), 2)
+        self.assertEqual(len(t.indexes), 2)
 
         i0 = t.getIndex(0)
-        self.assertEquals(i0.relative, 0)
-        self.assertEquals(i0.absolute, 0)
-        self.assertEquals(i0.path, None)
-        self.assertEquals(i0.counter, 0)
+        self.assertEqual(i0.relative, 0)
+        self.assertEqual(i0.absolute, 0)
+        self.assertEqual(i0.path, None)
+        self.assertEqual(i0.counter, 0)
 
         i1 = t.getIndex(1)
-        self.assertEquals(i1.relative, 0)
-        self.assertEquals(i1.absolute, 32)
-        self.assertEquals(i1.path, 'data.wav')
-        self.assertEquals(i1.counter, 1)
+        self.assertEqual(i1.relative, 0)
+        self.assertEqual(i1.absolute, 32)
+        self.assertEqual(i1.path, 'data.wav')
+        self.assertEqual(i1.counter, 1)
 
         # track 11, Vamos
 
         t = self.toc.table.tracks[10]
-        self.assertEquals(len(t.indexes), 2)
+        self.assertEqual(len(t.indexes), 2)
 
         # 32 frames of silence, and 1483 seconds of data.wav
-        self.assertEquals(t.getIndex(1).relative, 111225)
-        self.assertEquals(t.getIndex(1).absolute, 111257)
-        self.assertEquals(t.getIndex(2).relative, 111225 + 3370)
-        self.assertEquals(t.getIndex(2).absolute, 111257 + 3370)
+        self.assertEqual(t.getIndex(1).relative, 111225)
+        self.assertEqual(t.getIndex(1).absolute, 111257)
+        self.assertEqual(t.getIndex(2).relative, 111225 + 3370)
+        self.assertEqual(t.getIndex(2).absolute, 111257 + 3370)

--- a/whipper/test/test_program_cdparanoia.py
+++ b/whipper/test/test_program_cdparanoia.py
@@ -25,7 +25,7 @@ class ParseTestCase(common.TestCase):
             self._parser.parse(line)
 
         q = '%.01f %%' % (self._parser.getTrackQuality() * 100.0, )
-        self.assertEquals(q, '99.6 %')
+        self.assertEqual(q, '99.6 %')
 
 
 class Parse1FrameTestCase(common.TestCase):
@@ -42,7 +42,7 @@ class Parse1FrameTestCase(common.TestCase):
             self._parser.parse(line)
 
         q = '%.01f %%' % (self._parser.getTrackQuality() * 100.0, )
-        self.assertEquals(q, '100.0 %')
+        self.assertEqual(q, '100.0 %')
 
 
 class ErrorTestCase(common.TestCase):
@@ -60,14 +60,14 @@ class ErrorTestCase(common.TestCase):
             self._parser.parse(line)
 
         q = '%.01f %%' % (self._parser.getTrackQuality() * 100.0, )
-        self.assertEquals(q, '79.6 %')
+        self.assertEqual(q, '79.6 %')
 
 
 class VersionTestCase(common.TestCase):
 
     def testGetVersion(self):
         v = cdparanoia.getCdParanoiaVersion()
-        self.failUnless(v)
+        self.assertTrue(v)
 
 
 class AnalyzeFileTask(cdparanoia.AnalyzeTask):
@@ -88,4 +88,4 @@ class CacheTestCase(common.TestCase):
                             'cdparanoia', 'PX-L890SA.cdparanoia-A.stderr')
         t = AnalyzeFileTask(path)
         self.runner.run(t)
-        self.failUnless(t.defeatsCache)
+        self.assertTrue(t.defeatsCache)

--- a/whipper/test/test_program_cdrdao.py
+++ b/whipper/test/test_program_cdrdao.py
@@ -10,6 +10,6 @@ from whipper.test import common
 class VersionTestCase(common.TestCase):
     def testGetVersion(self):
         v = cdrdao.getCDRDAOVersion()
-        self.failUnless(v)
+        self.assertTrue(v)
         # make sure it starts with a digit
-        self.failUnless(int(v[0]))
+        self.assertTrue(int(v[0]))

--- a/whipper/test/test_program_sox.py
+++ b/whipper/test/test_program_sox.py
@@ -11,4 +11,4 @@ class PeakLevelTestCase(common.TestCase):
         self.path = os.path.join(os.path.dirname(__file__), 'track.flac')
 
     def testParse(self):
-        self.assertEquals(26215, sox.peak_level(self.path))
+        self.assertEqual(26215, sox.peak_level(self.path))

--- a/whipper/test/test_program_soxi.py
+++ b/whipper/test/test_program_soxi.py
@@ -19,7 +19,7 @@ class AudioLengthTestCase(tcommon.TestCase):
         t = AudioLengthTask(path)
         runner = task.SyncRunner()
         runner.run(t, verbose=False)
-        self.assertEquals(t.length, base_track_length)
+        self.assertEqual(t.length, base_track_length)
 
 
 class AudioLengthPathTestCase(tcommon.TestCase):
@@ -32,7 +32,7 @@ class AudioLengthPathTestCase(tcommon.TestCase):
         t = AudioLengthTask(path)
         runner = task.SyncRunner()
         runner.run(t, verbose=False)
-        self.assertEquals(t.length, base_track_length)
+        self.assertEqual(t.length, base_track_length)
         os.unlink(path)
 
 


### PR DESCRIPTION
This is a WIP.
I'm trying to introduce only incremental changes which can be merged right now because they retain backward compatibility with Python 2 (but explicitly target Python 3). The aim is to simplify the porting effort that will take place after milestone 1.0 has been reached.