### PR TITLE
Switch to PyGObject by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
     # Dependencies
     - sudo apt-get -qq update
     - sudo pip install --upgrade -qq pip
-    - sudo apt-get -qq install cdparanoia cdrdao flac libcdio-dev libiso9660-dev libsndfile1-dev python-cddb python-gobject python-musicbrainzngs python-mutagen python-setuptools sox swig libcdio-utils
+    - sudo apt-get -qq install cdparanoia cdrdao flac gir1.2-glib-2.0 libcdio-dev libiso9660-dev libsndfile1-dev python-cddb python-gi python-musicbrainzngs python-mutagen python-setuptools sox swig libcdio-utils
     - sudo pip install pycdio==0.21 requests
 
     # Testing dependencies

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Whipper relies on the following packages in order to run correctly and provide a
 - [cd-paranoia](https://www.gnu.org/software/libcdio/), for the actual ripping
   - To avoid bugs it's advised to use `cd-paranoia` **10.2+0.94+2-2**
 - [cdrdao](http://cdrdao.sourceforge.net/), for session, TOC, pre-gap, and ISRC extraction
-- [python-gobject-2](https://packages.debian.org/en/jessie/python-gobject-2), required by `task.py`
+- [PyGObject](https://pypi.org/project/PyGObject/), required by `task.py`
 - [python-musicbrainzngs](https://github.com/alastair/python-musicbrainzngs), for metadata lookup
 - [python-mutagen](https://pypi.python.org/pypi/mutagen), for tagging support
 - [python-setuptools](https://pypi.python.org/pypi/setuptools), for installation, plugins support

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Whipper relies on the following packages in order to run correctly and provide a
 - [cd-paranoia](https://www.gnu.org/software/libcdio/), for the actual ripping
   - To avoid bugs it's advised to use `cd-paranoia` **10.2+0.94+2-2**
 - [cdrdao](http://cdrdao.sourceforge.net/), for session, TOC, pre-gap, and ISRC extraction
+- [GObject Introspection](https://wiki.gnome.org/Projects/GObjectIntrospection), to provide GLib-2.0 methods used by `task.py`
 - [PyGObject](https://pypi.org/project/PyGObject/), required by `task.py`
 - [python-musicbrainzngs](https://github.com/alastair/python-musicbrainzngs), for metadata lookup
 - [python-mutagen](https://pypi.python.org/pypi/mutagen), for tagging support

--- a/whipper/command/cd.py
+++ b/whipper/command/cd.py
@@ -24,15 +24,12 @@ import os
 import glob
 import sys
 import logging
-import gobject
 from whipper.command.basecommand import BaseCommand
 from whipper.common import (
     accurip, config, drive, program, task
 )
 from whipper.program import cdrdao, cdparanoia, utils
 from whipper.result import result
-
-gobject.threads_init()
 
 logger = logging.getLogger(__name__)
 

--- a/whipper/command/offset.py
+++ b/whipper/command/offset.py
@@ -23,14 +23,11 @@ import os
 import sys
 import tempfile
 import logging
-import gobject
 from whipper.command.basecommand import BaseCommand
 from whipper.common import accurip, common, config, drive
 from whipper.common import task as ctask
 from whipper.program import arc, cdrdao, cdparanoia, utils
 from whipper.extern.task import task
-
-gobject.threads_init()
 
 logger = logging.getLogger(__name__)
 

--- a/whipper/extern/task/task.py
+++ b/whipper/extern/task/task.py
@@ -21,7 +21,10 @@
 import logging
 import sys
 
-import gobject
+try:
+    from gi.repository import GLib as gobject
+except ImportError:
+    import gobject
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
AFAICT, PyGObject supersedes python-gobject-2.

To quote https://packages.debian.org/en/jessie/python-gobject-2:
> This package contains the static Python bindings for gobject, glib, and gio. These are deprecated by dynamic gobject-introspection bindings (which are provided with the python-gobject package), and should not be used in newly written code. These static bindings just exist to provide backwards compatibility for GNOME 2 based software.

In Debian, the Package providing PyGObject is called `python-gi` (also installed by transitional package `python-gobject`).