### PR TITLE
task: implement logging

### DIFF
--- a/whipper/extern/task/task.py
+++ b/whipper/extern/task/task.py
@@ -18,9 +18,12 @@
 # You should have received a copy of the GNU General Public License
 # along with whipper.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 import sys
 
 import gobject
+
+logger = logging.getLogger(__name__)
 
 
 class TaskException(Exception):
@@ -70,21 +73,14 @@ class LogStub(object):
     I am a stub for a log interface.
     """
 
-    # log stubs
     def log(self, message, *args):
-        pass
+        logger.info(message, *args)
 
     def debug(self, message, *args):
-        pass
-
-    def info(self, message, *args):
-        pass
+        logger.debug(message, *args)
 
     def warning(self, message, *args):
-        pass
-
-    def error(self, message, *args):
-        pass
+        logger.warning(message, *args)
 
 
 class Task(LogStub):


### PR DESCRIPTION
The task module has debug statements, which never appear in a debug log. This may create the false impression, that some functions won't ever get called. Therefore, this patch modifies the LogStub class to use standard Python logging. Unused methods are removed.