### PR TITLE
Handle FreeDB server errors gracefully 

### DIFF
--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -251,6 +251,9 @@ class Program:
             logger.debug('CDDB query result: %r', md)
             return [item['DTITLE'] for item in md if 'DTITLE' in item] or None
 
+        except ValueError as e:
+            self._stdout.write("WARNING: CDDB protocol error: %s\n" % e)
+
         except IOError as e:
             # FIXME: for some reason errno is a str ?
             if e.errno == 'socket error':

--- a/whipper/common/program.py
+++ b/whipper/common/program.py
@@ -257,7 +257,7 @@ class Program:
         except IOError as e:
             # FIXME: for some reason errno is a str ?
             if e.errno == 'socket error':
-                self._stdout.write("Warning: network error: %r\n" % (e, ))
+                self._stdout.write("WARNING: CDDB network error: %r\n" % (e, ))
             else:
                 raise
 

--- a/whipper/extern/freedb.py
+++ b/whipper/extern/freedb.py
@@ -169,8 +169,9 @@ def freedb_command(freedb_server, freedb_port, cmd, *args):
 
     try:
         from urllib.request import urlopen
+        from urllib.error import URLError
     except ImportError:
-        from urllib2 import urlopen
+        from urllib2 import urlopen, URLError
     try:
         from urllib.parse import urlencode
     except ImportError:
@@ -203,11 +204,14 @@ def freedb_command(freedb_server, freedb_port, cmd, *args):
 
     POST.append((u"proto", u"6"))
 
-    # get Request object from post
-    request = urlopen(
-        "http://{}:{:d}/~cddb/cddb.cgi".format(freedb_server, freedb_port),
-        urlencode(POST).encode("UTF-8") if (version_info[0] >= 3) else
-        urlencode(POST))
+    try:
+        # get Request object from post
+        request = urlopen(
+            "http://{}:{:d}/~cddb/cddb.cgi".format(freedb_server, freedb_port),
+            urlencode(POST).encode("UTF-8") if (version_info[0] >= 3) else
+            urlencode(POST))
+    except URLError as e:
+        raise ValueError(str(e))
     try:
         # yield lines of output
         line = request.readline()


### PR DESCRIPTION
In my repeated tests, I ended up upsetting freedb.org, which started
issuing 502 errors. Those errors are not correctly caught by the
program which just crashes with a backtrace. Instead, we handle those
like any other API error, which can already be generated by
perform_lookup (but not handled).

The visible result for the user is that the CD is simply not found on
FreeDB, an acceptable compromise, in my opinion.

Closes: #206